### PR TITLE
Fix sidebar navigation and intervention form display

### DIFF
--- a/front-end-ui/client/components/InterventionForm.tsx
+++ b/front-end-ui/client/components/InterventionForm.tsx
@@ -143,7 +143,7 @@ export default function InterventionForm({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-5xl w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl">
+      <DialogContent className="max-w-5xl w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl z-[100]">
         <div className="flex flex-col h-full">
           {/* Header */}
           <DialogHeader className="px-8 pt-8 pb-6 border-b border-gray-200">

--- a/front-end-ui/client/components/InterventionForm.tsx
+++ b/front-end-ui/client/components/InterventionForm.tsx
@@ -143,7 +143,7 @@ export default function InterventionForm({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-5xl w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl z-[100]">
+      <DialogContent className="max-w-5xl w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl">
         <div className="flex flex-col h-full">
           {/* Header */}
           <DialogHeader className="px-8 pt-8 pb-6 border-b border-gray-200">

--- a/front-end-ui/client/components/TechnicianSidebar.tsx
+++ b/front-end-ui/client/components/TechnicianSidebar.tsx
@@ -38,8 +38,8 @@ export default function TechnicianSidebar({
 
   const basePath =
     userRole === "technicien_sup"
-      ? "/technicien-sup-dashboard"
-      : "/technician-dashboard";
+      ? "/technicien-sup"
+      : "/technician";
 
   const sidebarItems: SidebarItem[] = [
     {

--- a/front-end-ui/client/components/TechnicianSidebar.tsx
+++ b/front-end-ui/client/components/TechnicianSidebar.tsx
@@ -85,6 +85,7 @@ export default function TechnicianSidebar({
       label: "Interventions",
       icon: <Bell className="h-5 w-5" />,
       onClick: () => {
+        setIsOpen(false); // Close sidebar first
         onInterventionClick?.();
       },
     },

--- a/front-end-ui/client/components/ui/dialog.tsx
+++ b/front-end-ui/client/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[70] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/front-end-ui/client/components/ui/dialog.tsx
+++ b/front-end-ui/client/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[60] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/front-end-ui/client/pages/TechnicianDashboard.tsx
+++ b/front-end-ui/client/pages/TechnicianDashboard.tsx
@@ -33,6 +33,7 @@ import {
   LogOut,
   Sprout,
   Calendar,
+  Bell,
 } from "lucide-react";
 import TechnicianSidebar from "../components/TechnicianSidebar";
 import InterventionForm from "../components/InterventionForm";
@@ -482,7 +483,7 @@ export default function TechnicianDashboard() {
                             }
                           >
                             <SelectTrigger>
-                              <SelectValue placeholder="Sélectionnez une variété" />
+                              <SelectValue placeholder="S��lectionnez une variété" />
                             </SelectTrigger>
                             <SelectContent>
                               {cropVarieties.map((variety) => (

--- a/front-end-ui/client/pages/TechnicienSupDashboard.tsx
+++ b/front-end-ui/client/pages/TechnicienSupDashboard.tsx
@@ -38,6 +38,7 @@ import {
   Users,
   LogOut,
   Shield,
+  Bell,
 } from "lucide-react";
 import TechnicianSidebar from "../components/TechnicianSidebar";
 import InterventionForm from "../components/InterventionForm";


### PR DESCRIPTION
## Purpose
Fix broken sidebar navigation and intervention form display issues. The user reported that the sidebar navigation stopped working and the intervention form was not displaying properly, showing only a black overlay instead of the form content.

## Code changes
- **Fixed navigation paths**: Updated base paths in `TechnicianSidebar.tsx` from `/technicien-sup-dashboard` and `/technician-dashboard` to `/technicien-sup` and `/technician`
- **Improved sidebar behavior**: Added `setIsOpen(false)` to close sidebar when intervention button is clicked
- **Fixed dialog z-index issues**: Increased z-index values in `dialog.tsx` from `z-50` to `z-[60]` for overlay and `z-[70]` for content to ensure proper layering
- **Added missing imports**: Added `Bell` icon import to both dashboard components for intervention functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 181`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7a8c14de35d84c24ad03958a8d97bab7/cosmos-haven)

👀 [Preview Link](https://7a8c14de35d84c24ad03958a8d97bab7-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a8c14de35d84c24ad03958a8d97bab7</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->