### PR TITLE
Redesign intervention form layout and styling

### DIFF
--- a/front-end-ui/client/components/InterventionForm.tsx
+++ b/front-end-ui/client/components/InterventionForm.tsx
@@ -143,209 +143,206 @@ export default function InterventionForm({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-5xl w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl">
-        <div className="flex flex-col h-full">
-          {/* Header */}
-          <DialogHeader className="px-8 pt-8 pb-6 border-b border-gray-200">
-            <DialogTitle className="text-xl font-semibold text-gray-900">
-              Nouvelle Intervention
-            </DialogTitle>
-          </DialogHeader>
-
-          {/* Form Content */}
-          <div className="flex-1 px-8 py-6">
-            <form className="space-y-8">
-              {/* Row 1: Type d'intervention & ID Serre */}
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="space-y-3">
-                  <Label htmlFor="intervention-type" className="text-sm font-semibold text-gray-900">
-                    Type d'intervention demandée
-                    <span className="text-red-500 ml-1">*</span>
-                  </Label>
-                  <Select
-                    value={formData.interventionType}
-                    onValueChange={(value) => updateFormData("interventionType", value)}
-                  >
-                    <SelectTrigger 
-                      className={cn(
-                        "h-12 border-gray-300 rounded-lg",
-                        errors.interventionType && "border-red-500 focus:border-red-500"
-                      )}
-                    >
-                      <SelectValue placeholder="Sélectionner un type d'intervention" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {interventionTypes.map((type) => (
-                        <SelectItem key={type.value} value={type.value}>
-                          {type.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {errors.interventionType && (
-                    <p className="text-sm text-red-500">{errors.interventionType}</p>
-                  )}
-                </div>
-
-                <div className="space-y-3">
-                  <Label htmlFor="serre-id" className="text-sm font-semibold text-gray-900">
-                    ID Serre
-                    <span className="text-red-500 ml-1">*</span>
-                  </Label>
-                  <Input
-                    id="serre-id"
-                    type="text"
-                    value={formData.serreId}
-                    onChange={(e) => updateFormData("serreId", e.target.value)}
-                    placeholder="Serre / Domaine / Bilan"
+      <DialogContent className="max-w-[1396px] w-[95vw] max-h-[90vh] overflow-y-auto p-0 rounded-xl border border-gray-200 shadow-sm">
+        <div className="flex h-[644px] p-8 items-center bg-white rounded-xl">
+          <form className="flex w-full h-[580px] flex-col justify-center items-start gap-8">
+            {/* Row 1: Type d'intervention & ID Serre */}
+            <div className="w-full h-[198px] flex justify-between">
+              <div className="flex w-[567px] flex-col justify-center items-start gap-3">
+                <Label htmlFor="intervention-type" className="flex items-start gap-0 text-sm font-semibold text-gray-900">
+                  Type d'intervention demandée
+                  <span className="text-red-500 ml-1">*</span>
+                </Label>
+                <Select
+                  value={formData.interventionType}
+                  onValueChange={(value) => updateFormData("interventionType", value)}
+                >
+                  <SelectTrigger
                     className={cn(
-                      "h-12 border-gray-300 rounded-lg",
-                      errors.serreId && "border-red-500 focus:border-red-500"
+                      "flex h-[47px] w-[567px] px-3 py-0 justify-between items-center rounded-lg border border-gray-300 bg-white",
+                      errors.interventionType && "border-red-500 focus:border-red-500"
                     )}
-                  />
-                  {errors.serreId && (
-                    <p className="text-sm text-red-500">{errors.serreId}</p>
-                  )}
-                </div>
+                  >
+                    <SelectValue
+                      placeholder="Sélectionner un type d'intervention"
+                      className="text-gray-900 font-normal text-base"
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {interventionTypes.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {errors.interventionType && (
+                  <p className="text-sm text-red-500">{errors.interventionType}</p>
+                )}
               </div>
 
-              {/* Row 2: Date d'intervention & Fonctionnaire */}
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="space-y-3">
-                  <Label htmlFor="intervention-date" className="text-sm font-semibold text-gray-900">
-                    Date de l'intervention
-                    <span className="text-red-500 ml-1">*</span>
-                  </Label>
-                  <div className="relative">
-                    <Input
-                      id="intervention-date"
-                      type="date"
-                      value={formData.interventionDate}
-                      onChange={(e) => updateFormData("interventionDate", e.target.value)}
+              <div className="flex w-[567px] flex-col justify-center items-start gap-3">
+                <Label htmlFor="serre-id" className="flex items-start gap-0 text-sm font-semibold text-gray-900">
+                  ID Serre
+                  <span className="text-red-500 ml-1">*</span>
+                </Label>
+                <Input
+                  id="serre-id"
+                  type="text"
+                  value={formData.serreId}
+                  onChange={(e) => updateFormData("serreId", e.target.value)}
+                  placeholder="Serre / Domaine / Bilan"
+                  className={cn(
+                    "flex w-[567px] h-[50px] px-4 py-0 items-center rounded-lg border border-gray-300 bg-white text-base text-gray-600",
+                    errors.serreId && "border-red-500 focus:border-red-500"
+                  )}
+                />
+                {errors.serreId && (
+                  <p className="text-sm text-red-500">{errors.serreId}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Row 2: Date d'intervention & Fonctionnaire */}
+            <div className="w-full flex justify-between">
+              <div className="flex w-[567px] flex-col justify-center items-start gap-3">
+                <Label htmlFor="intervention-date" className="flex items-start gap-0 text-sm font-semibold text-gray-900">
+                  Date de l'intervention
+                  <span className="text-red-500 ml-1">*</span>
+                </Label>
+                <div className="relative w-[567px] h-[52px]">
+                  <Input
+                    id="intervention-date"
+                    type="date"
+                    value={formData.interventionDate}
+                    onChange={(e) => updateFormData("interventionDate", e.target.value)}
+                    className={cn(
+                      "w-full h-full rounded-lg border border-gray-300 bg-white px-6 text-black text-lg font-normal",
+                      errors.interventionDate && "border-red-500 focus:border-red-500"
+                    )}
+                    placeholder="mm/dd/yyyy"
+                  />
+                  <svg className="absolute right-3 top-1/2 transform -translate-y-1/2 h-6 w-6" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6.75 3V5.25M17.25 3V5.25M3 18.75V7.5C3 6.90326 3.23705 6.33097 3.65901 5.90901C4.08097 5.48705 4.65326 5.25 5.25 5.25H18.75C19.3467 5.25 19.919 5.48705 20.341 5.90901C20.7629 6.33097 21 6.90326 21 7.5V18.75M3 18.75C3 19.3467 3.23705 19.919 3.65901 20.341C4.08097 20.7629 4.65326 21 5.25 21H18.75C19.3467 21 19.919 20.7629 20.341 20.341C20.7629 19.919 21 19.3467 21 18.75M3 18.75V11.25C3 10.6533 3.23705 10.081 3.65901 9.65901C4.08097 9.23705 4.65326 9 5.25 9H18.75C19.3467 9 19.919 9.23705 20.341 9.65901C20.7629 10.081 21 10.6533 21 11.25V18.75" stroke="black" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </div>
+                {errors.interventionDate && (
+                  <p className="text-sm text-red-500">{errors.interventionDate}</p>
+                )}
+              </div>
+
+              <div className="flex w-[567px] flex-col justify-center items-start gap-3">
+                <Label htmlFor="functionary" className="flex items-start gap-0 text-sm font-semibold text-gray-900">
+                  Fonctionnaire demandé
+                  <span className="text-red-500 ml-1">*</span>
+                </Label>
+                <Select
+                  value={formData.functionary}
+                  onValueChange={(value) => updateFormData("functionary", value)}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "flex h-[47px] w-[567px] px-3 py-0 justify-between items-center rounded-lg border border-gray-300 bg-white",
+                      errors.functionary && "border-red-500 focus:border-red-500"
+                    )}
+                  >
+                    <SelectValue
+                      placeholder="Sélectionner un fonctionnaire"
+                      className="text-gray-900 font-normal text-base"
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {functionaries.map((functionary) => (
+                      <SelectItem key={functionary.value} value={functionary.value}>
+                        {functionary.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {errors.functionary && (
+                  <p className="text-sm text-red-500">{errors.functionary}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Row 3: Description */}
+            <div className="flex w-full flex-col items-start gap-3">
+              <Label htmlFor="description" className="text-sm font-semibold text-gray-900">
+                Description de l'intervention (optionnel)
+              </Label>
+              <Textarea
+                id="description"
+                value={formData.description}
+                onChange={(e) => updateFormData("description", e.target.value)}
+                placeholder="Détails supplémentaires sur l'intervention..."
+                rows={5}
+                className="flex h-[122px] w-full p-4 items-start rounded-lg border border-gray-300 bg-white resize-none text-gray-600 text-base"
+              />
+            </div>
+
+            {/* Row 4: Priority */}
+            <div className="flex w-full h-[52px] flex-col justify-center items-start gap-3">
+              <Label className="text-sm font-semibold text-gray-900">
+                Priorité
+              </Label>
+              <RadioGroup
+                value={formData.priority}
+                onValueChange={(value: any) => updateFormData("priority", value)}
+                className="flex w-full items-start gap-6"
+              >
+                {priorityOptions.map((option) => (
+                  <div key={option.value} className="flex items-center justify-center gap-2">
+                    <RadioGroupItem
+                      value={option.value}
+                      id={option.value}
                       className={cn(
-                        "h-12 border-gray-300 rounded-lg pl-4 pr-12",
-                        errors.interventionDate && "border-red-500 focus:border-red-500"
+                        "w-4 h-4 rounded-full border-[0.5px] border-black",
+                        formData.priority === option.value && "border-blue-500 bg-blue-500"
                       )}
                     />
-                    <Calendar className="absolute right-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400 pointer-events-none" />
-                  </div>
-                  {errors.interventionDate && (
-                    <p className="text-sm text-red-500">{errors.interventionDate}</p>
-                  )}
-                </div>
-
-                <div className="space-y-3">
-                  <Label htmlFor="functionary" className="text-sm font-semibold text-gray-900">
-                    Fonctionnaire demandé
-                    <span className="text-red-500 ml-1">*</span>
-                  </Label>
-                  <Select
-                    value={formData.functionary}
-                    onValueChange={(value) => updateFormData("functionary", value)}
-                  >
-                    <SelectTrigger 
-                      className={cn(
-                        "h-12 border-gray-300 rounded-lg",
-                        errors.functionary && "border-red-500 focus:border-red-500"
-                      )}
+                    <Label
+                      htmlFor={option.value}
+                      className="text-sm font-normal cursor-pointer text-gray-600"
                     >
-                      <SelectValue placeholder="Sélectionner un fonctionnaire" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {functionaries.map((functionary) => (
-                        <SelectItem key={functionary.value} value={functionary.value}>
-                          {functionary.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {errors.functionary && (
-                    <p className="text-sm text-red-500">{errors.functionary}</p>
-                  )}
-                </div>
-              </div>
-
-              {/* Row 3: Description */}
-              <div className="space-y-3">
-                <Label htmlFor="description" className="text-sm font-semibold text-gray-900">
-                  Description de l'intervention (optionnel)
-                </Label>
-                <Textarea
-                  id="description"
-                  value={formData.description}
-                  onChange={(e) => updateFormData("description", e.target.value)}
-                  placeholder="Détails supplémentaires sur l'intervention..."
-                  rows={4}
-                  className="border-gray-300 rounded-lg resize-none"
-                />
-              </div>
-
-              {/* Row 4: Priority */}
-              <div className="space-y-3">
-                <Label className="text-sm font-semibold text-gray-900">
-                  Priorité
-                </Label>
-                <RadioGroup
-                  value={formData.priority}
-                  onValueChange={(value: any) => updateFormData("priority", value)}
-                  className="flex flex-wrap gap-6 pt-2"
-                >
-                  {priorityOptions.map((option) => (
-                    <div key={option.value} className="flex items-center space-x-2">
-                      <RadioGroupItem
-                        value={option.value}
-                        id={option.value}
-                        className={cn(
-                          "border-gray-400",
-                          formData.priority === option.value && "border-blue-500"
-                        )}
-                      />
-                      <Label 
-                        htmlFor={option.value} 
-                        className={cn(
-                          "text-sm font-normal cursor-pointer",
-                          option.color
-                        )}
-                      >
-                        {option.label}
-                      </Label>
-                    </div>
-                  ))}
-                </RadioGroup>
-              </div>
-            </form>
-          </div>
-
-          {/* Footer Actions */}
-          <div className="flex flex-col lg:flex-row justify-between items-stretch lg:items-center gap-4 px-4 sm:px-8 py-6 border-t border-gray-200 bg-gray-50">
-            <Button
-              variant="outline"
-              onClick={handleClose}
-              className="order-3 lg:order-1 w-full lg:w-auto px-6 py-3 border-gray-300 text-gray-600 hover:bg-gray-100"
-            >
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Annuler
-            </Button>
-
-            <div className="order-1 lg:order-2 flex flex-col sm:flex-row gap-3 w-full lg:w-auto">
-              <Button
-                variant="outline"
-                onClick={handleSaveDraft}
-                className="w-full sm:w-auto px-6 py-3 border-blue-300 text-blue-600 bg-blue-50 hover:bg-blue-100 flex items-center justify-center"
-              >
-                <Save className="h-4 w-4 mr-2" />
-                Sauvegarder en brouillon
-              </Button>
-
-              <Button
-                onClick={handleSubmit}
-                className="w-full sm:w-auto px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white shadow-lg flex items-center justify-center"
-              >
-                <Send className="h-4 w-4 mr-2" />
-                Envoyer la demande
-              </Button>
+                      {option.label}
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
             </div>
-          </div>
+
+            {/* Footer Actions */}
+            <div className="flex h-[73px] pt-6 justify-between items-start w-full border-t border-gray-200">
+              <Button
+                type="button"
+                onClick={handleClose}
+                className="flex h-12 px-6 justify-center items-start gap-2 rounded-lg bg-gray-100 hover:bg-gray-200 border-0"
+              >
+                <ArrowLeft className="h-4 w-4 text-gray-600" />
+                <span className="text-gray-600 text-center font-medium text-base">Annuler</span>
+              </Button>
+
+              <div className="flex justify-center items-start gap-4">
+                <Button
+                  type="button"
+                  onClick={handleSaveDraft}
+                  className="flex h-12 px-6 justify-center items-start gap-2 rounded-lg bg-blue-50 hover:bg-blue-100 border-0"
+                >
+                  <Save className="h-4 w-4 text-blue-600" />
+                  <span className="text-blue-600 text-center font-medium text-base">Sauvegarder en brouillon</span>
+                </Button>
+
+                <Button
+                  type="button"
+                  onClick={handleSubmit}
+                  className="flex h-12 px-6 justify-center items-start gap-2 rounded-lg bg-blue-800 hover:bg-blue-900 text-white shadow-md border-0"
+                >
+                  <Send className="h-4 w-4 text-white" />
+                  <span className="text-white text-center font-medium text-base">Envoyer la demande</span>
+                </Button>
+              </div>
+            </div>
+          </form>
         </div>
       </DialogContent>
     </Dialog>

--- a/front-end-ui/client/components/InterventionForm.tsx
+++ b/front-end-ui/client/components/InterventionForm.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
-import { Calendar, Save, Send, ArrowLeft } from "lucide-react";
+import { Calendar, Save, Send, ArrowLeft, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface InterventionFormProps {


### PR DESCRIPTION
## Purpose

The user requested to make a button in the interventions page interactive so that clicking it displays a form. This change implements a redesigned intervention form with improved layout and styling to enhance user interaction and visual presentation.

## Code changes

- **Layout restructuring**: Converted from flexible grid-based layout to fixed-width container (1396px) with precise positioning
- **Form styling updates**: 
  - Updated form container to use fixed dimensions (644px height, 580px form height)
  - Redesigned input fields with consistent sizing (567px width for most inputs)
  - Enhanced select dropdowns with improved styling and spacing
- **Visual improvements**:
  - Added custom calendar icon SVG for date input
  - Updated button styling with specific colors and hover states
  - Improved radio button styling with custom border and selection states
  - Enhanced textarea with fixed height (122px) and better padding
- **Component organization**: Restructured form sections with better spacing and alignment using flexbox layouts
- **Icon updates**: Added ChevronDown import for dropdown indicators

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 183`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52ddc23398fe4833ad8a9f359329585f/neon-forge)

👀 [Preview Link](https://52ddc23398fe4833ad8a9f359329585f-neon-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52ddc23398fe4833ad8a9f359329585f</projectId>-->
<!--<branchName>neon-forge</branchName>-->