### PR TITLE
Add interventions page with interactive button

### DIFF
--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -19,6 +19,7 @@ import DirecteurDashboard from "./pages/DirecteurDashboard";
 import TechnicianDashboard from "./pages/TechnicianDashboard";
 import TechnicienSupDashboard from "./pages/TechnicienSupDashboard";
 import TechnicienRegistration from "./pages/TechnicienRegistration";
+import Interventions from "./pages/Interventions";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();

--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -79,6 +79,14 @@ const App = () => (
                 </ProtectedRoute>
               }
             />
+            <Route
+              path="/interventions"
+              element={
+                <ProtectedRoute>
+                  <Interventions />
+                </ProtectedRoute>
+              }
+            />
 
             {/* Redirect root to dashboard if authenticated, otherwise to login */}
             <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/front-end-ui/client/components/TechnicianSidebar.tsx
+++ b/front-end-ui/client/components/TechnicianSidebar.tsx
@@ -84,9 +84,7 @@ export default function TechnicianSidebar({
       id: "interventions",
       label: "Interventions",
       icon: <Bell className="h-5 w-5" />,
-      onClick: () => {
-        onInterventionClick?.();
-      },
+      path: "/interventions",
     },
     {
       id: "rapports",

--- a/front-end-ui/client/pages/Interventions.tsx
+++ b/front-end-ui/client/pages/Interventions.tsx
@@ -3,10 +3,12 @@ import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import InterventionForm from "../components/InterventionForm";
 import TechnicianSidebar from "../components/TechnicianSidebar";
+import { useAuth } from "../contexts/AuthContext";
 import { cn } from "@/lib/utils";
 
 export default function Interventions() {
   const [isInterventionFormOpen, setIsInterventionFormOpen] = useState(false);
+  const { user } = useAuth();
 
   const handleInterventionSubmit = (data: any) => {
     console.log("Intervention submitted:", data);

--- a/front-end-ui/client/pages/Interventions.tsx
+++ b/front-end-ui/client/pages/Interventions.tsx
@@ -28,8 +28,8 @@ export default function Interventions() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center gap-4">
-              <TechnicianSidebar 
-                userRole="technicien"
+              <TechnicianSidebar
+                userRole={(user?.role === "technicien_sup" ? "technicien_sup" : "technicien") as "technicien" | "technicien_sup"}
                 onInterventionClick={() => setIsInterventionFormOpen(true)}
               />
               <div>

--- a/front-end-ui/client/pages/Interventions.tsx
+++ b/front-end-ui/client/pages/Interventions.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import InterventionForm from "../components/InterventionForm";
+import TechnicianSidebar from "../components/TechnicianSidebar";
+import { cn } from "@/lib/utils";
+
+export default function Interventions() {
+  const [isInterventionFormOpen, setIsInterventionFormOpen] = useState(false);
+
+  const handleInterventionSubmit = (data: any) => {
+    console.log("Intervention submitted:", data);
+    // TODO: Send to backend API
+    setIsInterventionFormOpen(false);
+  };
+
+  const handleInterventionSaveDraft = (data: any) => {
+    console.log("Intervention saved as draft:", data);
+    // TODO: Save draft to backend or local storage
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <div className="flex items-center gap-4">
+              <TechnicianSidebar 
+                userRole="technicien"
+                onInterventionClick={() => setIsInterventionFormOpen(true)}
+              />
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900">Interventions</h1>
+                <p className="text-sm text-gray-600">Gérez vos interventions</p>
+              </div>
+            </div>
+            
+            {/* Add Intervention Button */}
+            <Button 
+              size="sm" 
+              className="bg-[#B4CC5F] hover:bg-[#A3C247]"
+              onClick={() => setIsInterventionFormOpen(true)}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Nouvelle intervention
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Interventions List Placeholder */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto h-12 w-12 text-gray-400">
+              <Plus className="h-12 w-12" />
+            </div>
+            <h3 className="mt-2 text-sm font-medium text-gray-900">Aucune intervention</h3>
+            <p className="mt-1 text-sm text-gray-500">
+              Commencez par créer votre première intervention.
+            </p>
+            <div className="mt-6">
+              <Button 
+                size="sm" 
+                className="bg-[#B4CC5F] hover:bg-[#A3C247]"
+                onClick={() => setIsInterventionFormOpen(true)}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Nouvelle intervention
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Intervention Form Modal */}
+      <InterventionForm
+        isOpen={isInterventionFormOpen}
+        onClose={() => setIsInterventionFormOpen(false)}
+        onSubmit={handleInterventionSubmit}
+        onSaveDraft={handleInterventionSaveDraft}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Purpose

The user requested an interactive "Nouvelle intervention" button on the interventions page that opens an intervention form when clicked. They wanted to know where to find this button and how to implement the functionality to display the intervention form upon clicking.

## Code changes

- **Created new Interventions page** (`/pages/Interventions.tsx`) with a dedicated interventions management interface
- **Added routing** for `/interventions` path in `App.tsx` with protected route wrapper
- **Updated TechnicianSidebar** to navigate to the interventions page instead of using callback
- **Implemented interactive button** with the requested styling (`bg-[#B4CC5F] hover:bg-[#A3C247]`) and Plus icon
- **Added form modal integration** that opens `InterventionForm` component when button is clicked
- **Included placeholder content** for empty interventions list with call-to-action button

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 184`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52ddc23398fe4833ad8a9f359329585f/curry-zone)

👀 [Preview Link](https://52ddc23398fe4833ad8a9f359329585f-curry-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52ddc23398fe4833ad8a9f359329585f</projectId>-->
<!--<branchName>curry-zone</branchName>-->