### PR TITLE
Add user profile dropdown and dedicated profile page

### DIFF
--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -27,6 +27,11 @@ import ReportsPage from "./pages/ReportsPage";
 import Alerts from "./pages/Alerts";
 import Surveillance from "./pages/Surveillance";
 import Profile from "./pages/Profile";
+import TechnicianManagement from "./pages/TechnicianManagement";
+import AffiliationManagement from "./pages/AffiliationManagement";
+import InterventionManagement from "./pages/InterventionManagement";
+import AlertManagement from "./pages/AlertManagement";
+import ReportManagement from "./pages/ReportManagement";
 import NotFound from "./pages/NotFound";
 const queryClient = new QueryClient();
 

--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -26,6 +26,7 @@ import SurveillancePage from "./pages/SurveillancePage";
 import ReportsPage from "./pages/ReportsPage";
 import Alerts from "./pages/Alerts";
 import Surveillance from "./pages/Surveillance";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 const queryClient = new QueryClient();
 

--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -156,6 +156,37 @@ const App = () => (
               </ProtectedRoute>
             } />
 
+            {/* Director Management Routes */}
+            <Route path="/directeur/techniciens" element={
+              <ProtectedRoute>
+                <TechnicianManagement />
+              </ProtectedRoute>
+            } />
+
+            <Route path="/directeur/affiliations" element={
+              <ProtectedRoute>
+                <AffiliationManagement />
+              </ProtectedRoute>
+            } />
+
+            <Route path="/directeur/interventions" element={
+              <ProtectedRoute>
+                <InterventionManagement />
+              </ProtectedRoute>
+            } />
+
+            <Route path="/directeur/alertes" element={
+              <ProtectedRoute>
+                <AlertManagement />
+              </ProtectedRoute>
+            } />
+
+            <Route path="/directeur/rapports" element={
+              <ProtectedRoute>
+                <ReportManagement />
+              </ProtectedRoute>
+            } />
+
             {/* Redirect root to dashboard */}
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
 

--- a/front-end-ui/client/App.tsx
+++ b/front-end-ui/client/App.tsx
@@ -145,6 +145,12 @@ const App = () => (
               </ProtectedRoute>
             } />
 
+            <Route path="/profile" element={
+              <ProtectedRoute>
+                <Profile />
+              </ProtectedRoute>
+            } />
+
             {/* Redirect root to dashboard */}
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
 

--- a/front-end-ui/client/components/DirectorSidebar.tsx
+++ b/front-end-ui/client/components/DirectorSidebar.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import {
+  Menu,
+  LayoutDashboard,
+  Users,
+  UserCheck,
+  Wrench,
+  AlertTriangle,
+  FileText,
+  ChevronRight,
+  Home
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface DirectorSidebarProps {
+  className?: string;
+}
+
+interface NavItem {
+  title: string;
+  href: string;
+  icon: React.ElementType;
+  badge?: string;
+  description?: string;
+}
+
+const navigationItems: NavItem[] = [
+  {
+    title: "Tableau de bord",
+    href: "/directeur",
+    icon: LayoutDashboard,
+    description: "Vue d'ensemble et statistiques"
+  },
+  {
+    title: "Gestion des techniciens",
+    href: "/directeur/techniciens",
+    icon: Users,
+    description: "CRUD des comptes techniciens"
+  },
+  {
+    title: "Demandes d'affiliation",
+    href: "/directeur/affiliations",
+    icon: UserCheck,
+    badge: "3",
+    description: "Validation des nouveaux comptes"
+  },
+  {
+    title: "Gestion des interventions",
+    href: "/directeur/interventions",
+    icon: Wrench,
+    description: "Créer et assigner des interventions"
+  },
+  {
+    title: "Gestion des alertes",
+    href: "/directeur/alertes",
+    icon: AlertTriangle,
+    badge: "5",
+    description: "HeatMap et surveillance"
+  },
+  {
+    title: "Gestion des rapports",
+    href: "/directeur/rapports",
+    icon: FileText,
+    description: "Création et consultation des rapports"
+  }
+];
+
+export default function DirectorSidebar({ className }: DirectorSidebarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleNavigation = (href: string) => {
+    navigate(href);
+    setIsOpen(false);
+  };
+
+  const SidebarContent = ({ mobile = false }: { mobile?: boolean }) => (
+    <div className={cn("flex flex-col h-full", className)}>
+      {/* Header */}
+      <div className="p-6 border-b">
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+            <Home className="h-6 w-6 text-green-600" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Directeur</h2>
+            <p className="text-sm text-gray-500">Tableau de gestion</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 p-4 space-y-2 overflow-y-auto">
+        {navigationItems.map((item) => {
+          const isActive = location.pathname === item.href || 
+                          (item.href !== "/directeur" && location.pathname.startsWith(item.href));
+          
+          return (
+            <Button
+              key={item.href}
+              variant="ghost"
+              className={cn(
+                "w-full justify-start h-auto p-4 text-left",
+                isActive 
+                  ? "bg-green-50 text-green-700 border border-green-200" 
+                  : "text-gray-700 hover:bg-gray-50"
+              )}
+              onClick={() => handleNavigation(item.href)}
+            >
+              <div className="flex items-center w-full">
+                <item.icon className={cn(
+                  "h-5 w-5 mr-3 flex-shrink-0",
+                  isActive ? "text-green-600" : "text-gray-400"
+                )} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium truncate">{item.title}</span>
+                    <div className="flex items-center space-x-2">
+                      {item.badge && (
+                        <Badge 
+                          variant="secondary" 
+                          className="bg-red-100 text-red-700 text-xs px-2"
+                        >
+                          {item.badge}
+                        </Badge>
+                      )}
+                      <ChevronRight className={cn(
+                        "h-4 w-4 flex-shrink-0",
+                        isActive ? "text-green-600" : "text-gray-400"
+                      )} />
+                    </div>
+                  </div>
+                  {item.description && (
+                    <p className="text-xs text-gray-500 mt-1 truncate">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Button>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div className="p-4 border-t bg-gray-50">
+        <div className="text-xs text-gray-500 text-center">
+          <p>Système de gestion agricole</p>
+          <p className="mt-1">v2.0</p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile Sidebar */}
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="md:hidden flex items-center space-x-2"
+          >
+            <Menu className="h-4 w-4" />
+            <span>Menu</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="left" className="p-0 w-80">
+          <SidebarContent mobile />
+        </SheetContent>
+      </Sheet>
+
+      {/* Desktop Sidebar */}
+      <div className="hidden md:flex md:flex-shrink-0">
+        <div className="flex flex-col w-80 bg-white border-r border-gray-200">
+          <SidebarContent />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front-end-ui/client/components/PageHeader.tsx
+++ b/front-end-ui/client/components/PageHeader.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { useAuth } from "../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { LogOut } from "lucide-react";
+import { LogOut, User, ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import TechnicianSidebar from "./TechnicianSidebar";
 
 interface PageHeaderProps {

--- a/front-end-ui/client/components/PageHeader.tsx
+++ b/front-end-ui/client/components/PageHeader.tsx
@@ -25,14 +25,15 @@ interface PageHeaderProps {
   actions?: React.ReactNode;
 }
 
-export default function PageHeader({ 
-  title, 
-  subtitle, 
-  badge, 
+export default function PageHeader({
+  title,
+  subtitle,
+  badge,
   userRole = "technicien",
-  actions 
+  actions
 }: PageHeaderProps) {
   const { user, logout } = useAuth();
+  const navigate = useNavigate();
 
   return (
     <header className="bg-white shadow-sm border-b sticky top-0 z-10">

--- a/front-end-ui/client/components/PageHeader.tsx
+++ b/front-end-ui/client/components/PageHeader.tsx
@@ -77,21 +77,57 @@ export default function PageHeader({
               </div>
             )}
             
-            {/* User Info */}
-            <span className="text-sm text-gray-600 hidden sm:block">
-              {user?.name || user?.email}
-            </span>
-            
-            {/* Logout Button */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => logout()}
-              className="flex items-center space-x-1"
-            >
-              <LogOut className="h-4 w-4" />
-              <span className="hidden sm:inline">Déconnexion</span>
-            </Button>
+            {/* User Profile Dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center space-x-2 hover:bg-gray-100 transition-colors duration-200 px-3 py-2 rounded-md"
+                >
+                  <div className="hidden sm:flex items-center space-x-2">
+                    <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+                      <User className="h-4 w-4 text-blue-600" />
+                    </div>
+                    <div className="text-left">
+                      <div className="text-sm font-medium text-gray-900">
+                        {user?.name || "Utilisateur"}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {user?.email}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="sm:hidden w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+                    <User className="h-4 w-4 text-blue-600" />
+                  </div>
+                  <ChevronDown className="h-4 w-4 text-gray-400" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <div className="px-2 py-1.5">
+                  <div className="text-sm font-medium text-gray-900">
+                    {user?.name || "Utilisateur"}
+                  </div>
+                  <div className="text-xs text-gray-500">{user?.email}</div>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => navigate("/profile")}
+                  className="flex items-center space-x-2 cursor-pointer"
+                >
+                  <User className="h-4 w-4" />
+                  <span>Mon Profil</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => logout()}
+                  className="flex items-center space-x-2 cursor-pointer text-red-600 focus:text-red-600"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span>Déconnexion</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/front-end-ui/client/pages/AffiliationManagement.tsx
+++ b/front-end-ui/client/pages/AffiliationManagement.tsx
@@ -1,0 +1,566 @@
+import React, { useState, useEffect } from "react";
+import DirectorSidebar from "../components/DirectorSidebar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle,
+  DialogDescription
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  UserCheck,
+  UserX,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Mail,
+  Phone,
+  MapPin,
+  Calendar,
+  FileText,
+  Eye
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface AffiliationRequest {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  requestedRole: "technicien" | "technicien_sup";
+  company?: string;
+  location?: string;
+  experience?: string;
+  motivation?: string;
+  requestDate: string;
+  status: "pending" | "approved" | "rejected";
+  documents?: string[];
+  avatar?: string;
+}
+
+export default function AffiliationManagement() {
+  const { toast } = useToast();
+  const [requests, setRequests] = useState<AffiliationRequest[]>([]);
+  const [selectedRequest, setSelectedRequest] = useState<AffiliationRequest | null>(null);
+  const [activeTab, setActiveTab] = useState("pending");
+
+  // Mock data - replace with real API calls
+  useEffect(() => {
+    const mockRequests: AffiliationRequest[] = [
+      {
+        id: "1",
+        name: "Thomas Rousseau",
+        email: "thomas.rousseau@example.com",
+        phone: "+33 6 11 22 33 44",
+        requestedRole: "technicien",
+        company: "Agri-Tech Solutions",
+        location: "Bordeaux, France",
+        experience: "3 ans d'expérience en maintenance agricole",
+        motivation: "Passionné par l'agriculture moderne et les technologies vertes.",
+        requestDate: "2024-01-20",
+        status: "pending",
+        documents: ["CV_Thomas_Rousseau.pdf", "Certificat_Formation.pdf"]
+      },
+      {
+        id: "2",
+        name: "Emma Leclerc",
+        email: "emma.leclerc@example.com",
+        phone: "+33 6 55 66 77 88",
+        requestedRole: "technicien_sup",
+        company: "Green Solutions SARL",
+        location: "Nantes, France",
+        experience: "5 ans en tant que technicienne senior, spécialisée en systèmes d'irrigation",
+        motivation: "Souhaitant rejoindre une équipe innovante dans le domaine agricole.",
+        requestDate: "2024-01-18",
+        status: "pending",
+        documents: ["CV_Emma_Leclerc.pdf", "Diplome_Ingenieur.pdf", "Recommandations.pdf"]
+      },
+      {
+        id: "3",
+        name: "Julien Moreau",
+        email: "julien.moreau@example.com",
+        requestedRole: "technicien",
+        location: "Strasbourg, France",
+        experience: "2 ans d'expérience en maintenance d'équipements",
+        motivation: "Intéressé par le développement durable et l'agriculture de précision.",
+        requestDate: "2024-01-15",
+        status: "approved"
+      },
+      {
+        id: "4",
+        name: "Alice Bernard",
+        email: "alice.bernard@example.com",
+        requestedRole: "technicien_sup",
+        location: "Lille, France",
+        experience: "1 an d'expérience",
+        motivation: "Motivation insuffisante pour le poste de technicien supérieur.",
+        requestDate: "2024-01-10",
+        status: "rejected"
+      }
+    ];
+    setRequests(mockRequests);
+  }, []);
+
+  const handleApproveRequest = (id: string) => {
+    const updatedRequests = requests.map(request =>
+      request.id === id ? { ...request, status: "approved" as const } : request
+    );
+    setRequests(updatedRequests);
+    
+    const requestName = requests.find(r => r.id === id)?.name;
+    toast({
+      title: "Demande approuvée",
+      description: `La demande de ${requestName} a été approuvée.`,
+    });
+  };
+
+  const handleRejectRequest = (id: string) => {
+    const updatedRequests = requests.map(request =>
+      request.id === id ? { ...request, status: "rejected" as const } : request
+    );
+    setRequests(updatedRequests);
+    
+    const requestName = requests.find(r => r.id === id)?.name;
+    toast({
+      title: "Demande rejetée",
+      description: `La demande de ${requestName} a été rejetée.`,
+      variant: "destructive",
+    });
+  };
+
+  const getFilteredRequests = (status: string) => {
+    if (status === "all") return requests;
+    return requests.filter(request => request.status === status);
+  };
+
+  const getRoleDisplayName = (role: string) => {
+    return role === "technicien_sup" ? "Technicien Supérieur" : "Technicien";
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "approved":
+        return "bg-green-50 border-green-200 text-green-700";
+      case "rejected":
+        return "bg-red-50 border-red-200 text-red-700";
+      case "pending":
+        return "bg-yellow-50 border-yellow-200 text-yellow-700";
+      default:
+        return "bg-gray-50 border-gray-200 text-gray-700";
+    }
+  };
+
+  const getStatusDisplayName = (status: string) => {
+    switch (status) {
+      case "approved":
+        return "Approuvée";
+      case "rejected":
+        return "Rejetée";
+      case "pending":
+        return "En attente";
+      default:
+        return "Non défini";
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case "approved":
+        return CheckCircle;
+      case "rejected":
+        return XCircle;
+      case "pending":
+        return Clock;
+      default:
+        return Clock;
+    }
+  };
+
+  const RequestCard = ({ request }: { request: AffiliationRequest }) => {
+    const StatusIcon = getStatusIcon(request.status);
+    
+    return (
+      <Card className="hover:shadow-md transition-shadow">
+        <CardContent className="p-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <Avatar className="h-12 w-12">
+                <AvatarImage src={request.avatar} />
+                <AvatarFallback>
+                  {request.name.split(' ').map(n => n[0]).join('')}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {request.name}
+                </h3>
+                <div className="flex items-center space-x-4 text-sm text-gray-600">
+                  <span className="flex items-center">
+                    <Mail className="h-4 w-4 mr-1" />
+                    {request.email}
+                  </span>
+                  {request.phone && (
+                    <span className="flex items-center">
+                      <Phone className="h-4 w-4 mr-1" />
+                      {request.phone}
+                    </span>
+                  )}
+                  {request.location && (
+                    <span className="flex items-center">
+                      <MapPin className="h-4 w-4 mr-1" />
+                      {request.location}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center space-x-2 mt-2">
+                  <Badge variant="outline">
+                    {getRoleDisplayName(request.requestedRole)}
+                  </Badge>
+                  <span className="flex items-center text-sm text-gray-500">
+                    <Calendar className="h-4 w-4 mr-1" />
+                    {new Date(request.requestDate).toLocaleDateString('fr-FR')}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-4">
+              <div className="text-right">
+                <Badge variant="outline" className={getStatusColor(request.status)}>
+                  <StatusIcon className="h-3 w-3 mr-1" />
+                  {getStatusDisplayName(request.status)}
+                </Badge>
+                {request.documents && (
+                  <div className="flex items-center text-sm text-gray-500 mt-1">
+                    <FileText className="h-4 w-4 mr-1" />
+                    {request.documents.length} document(s)
+                  </div>
+                )}
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSelectedRequest(request)}
+                >
+                  <Eye className="h-4 w-4 mr-1" />
+                  Détails
+                </Button>
+
+                {request.status === "pending" && (
+                  <>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button size="sm" className="bg-green-600 hover:bg-green-700">
+                          <UserCheck className="h-4 w-4 mr-1" />
+                          Approuver
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Approuver la demande</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Êtes-vous sûr de vouloir approuver la demande d'affiliation de {request.name} ? 
+                            Un compte sera automatiquement créé.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Annuler</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleApproveRequest(request.id)}
+                            className="bg-green-600 hover:bg-green-700"
+                          >
+                            Approuver
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="outline" size="sm" className="text-red-600 hover:text-red-700">
+                          <UserX className="h-4 w-4 mr-1" />
+                          Rejeter
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Rejeter la demande</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Êtes-vous sûr de vouloir rejeter la demande d'affiliation de {request.name} ? 
+                            Cette action peut être annulée ultérieurement.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Annuler</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleRejectRequest(request.id)}
+                            className="bg-red-600 hover:bg-red-700"
+                          >
+                            Rejeter
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  const pendingCount = requests.filter(r => r.status === "pending").length;
+  const approvedCount = requests.filter(r => r.status === "approved").length;
+  const rejectedCount = requests.filter(r => r.status === "rejected").length;
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Gestion des demandes d'affiliation
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Validez les comptes de techniciens et techniciens supérieurs
+              </p>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-yellow-50 border-yellow-200 text-yellow-700">
+                <Clock className="h-3 w-3 mr-1" />
+                {pendingCount} en attente
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">En attente</p>
+                    <p className="text-3xl font-bold text-yellow-600">{pendingCount}</p>
+                  </div>
+                  <Clock className="h-8 w-8 text-yellow-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Approuvées</p>
+                    <p className="text-3xl font-bold text-green-600">{approvedCount}</p>
+                  </div>
+                  <CheckCircle className="h-8 w-8 text-green-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Rejetées</p>
+                    <p className="text-3xl font-bold text-red-600">{rejectedCount}</p>
+                  </div>
+                  <XCircle className="h-8 w-8 text-red-600" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Tabs for different request statuses */}
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-4">
+              <TabsTrigger value="pending">En attente ({pendingCount})</TabsTrigger>
+              <TabsTrigger value="approved">Approuvées ({approvedCount})</TabsTrigger>
+              <TabsTrigger value="rejected">Rejetées ({rejectedCount})</TabsTrigger>
+              <TabsTrigger value="all">Toutes ({requests.length})</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="pending" className="space-y-4">
+              {getFilteredRequests("pending").map((request) => (
+                <RequestCard key={request.id} request={request} />
+              ))}
+              {getFilteredRequests("pending").length === 0 && (
+                <Card>
+                  <CardContent className="p-12 text-center">
+                    <Clock className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">
+                      Aucune demande en attente
+                    </h3>
+                    <p className="text-gray-600">
+                      Toutes les demandes d'affiliation ont été traitées.
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+            </TabsContent>
+
+            <TabsContent value="approved" className="space-y-4">
+              {getFilteredRequests("approved").map((request) => (
+                <RequestCard key={request.id} request={request} />
+              ))}
+            </TabsContent>
+
+            <TabsContent value="rejected" className="space-y-4">
+              {getFilteredRequests("rejected").map((request) => (
+                <RequestCard key={request.id} request={request} />
+              ))}
+            </TabsContent>
+
+            <TabsContent value="all" className="space-y-4">
+              {requests.map((request) => (
+                <RequestCard key={request.id} request={request} />
+              ))}
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+
+      {/* Request Details Modal */}
+      <Dialog open={!!selectedRequest} onOpenChange={() => setSelectedRequest(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Détails de la demande d'affiliation</DialogTitle>
+            <DialogDescription>
+              Informations complètes du candidat
+            </DialogDescription>
+          </DialogHeader>
+          {selectedRequest && (
+            <div className="space-y-6">
+              <div className="flex items-center space-x-4">
+                <Avatar className="h-16 w-16">
+                  <AvatarImage src={selectedRequest.avatar} />
+                  <AvatarFallback className="text-lg">
+                    {selectedRequest.name.split(' ').map(n => n[0]).join('')}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <h3 className="text-xl font-semibold">{selectedRequest.name}</h3>
+                  <p className="text-gray-600">{selectedRequest.email}</p>
+                  <Badge variant="outline" className={getStatusColor(selectedRequest.status)}>
+                    {getStatusDisplayName(selectedRequest.status)}
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Rôle demandé</label>
+                  <p className="mt-1">{getRoleDisplayName(selectedRequest.requestedRole)}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Date de demande</label>
+                  <p className="mt-1">{new Date(selectedRequest.requestDate).toLocaleDateString('fr-FR')}</p>
+                </div>
+                {selectedRequest.phone && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Téléphone</label>
+                    <p className="mt-1">{selectedRequest.phone}</p>
+                  </div>
+                )}
+                {selectedRequest.location && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Localisation</label>
+                    <p className="mt-1">{selectedRequest.location}</p>
+                  </div>
+                )}
+                {selectedRequest.company && (
+                  <div className="col-span-2">
+                    <label className="text-sm font-medium text-gray-700">Entreprise actuelle</label>
+                    <p className="mt-1">{selectedRequest.company}</p>
+                  </div>
+                )}
+              </div>
+
+              {selectedRequest.experience && (
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Expérience</label>
+                  <p className="mt-1 text-gray-900">{selectedRequest.experience}</p>
+                </div>
+              )}
+
+              {selectedRequest.motivation && (
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Motivation</label>
+                  <p className="mt-1 text-gray-900">{selectedRequest.motivation}</p>
+                </div>
+              )}
+
+              {selectedRequest.documents && selectedRequest.documents.length > 0 && (
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Documents joints</label>
+                  <div className="mt-2 space-y-2">
+                    {selectedRequest.documents.map((doc, index) => (
+                      <div key={index} className="flex items-center space-x-2 p-2 bg-gray-50 rounded">
+                        <FileText className="h-4 w-4 text-gray-600" />
+                        <span className="text-sm">{doc}</span>
+                        <Button variant="outline" size="sm" className="ml-auto">
+                          Télécharger
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {selectedRequest.status === "pending" && (
+                <div className="flex space-x-3 pt-4 border-t">
+                  <Button
+                    onClick={() => {
+                      handleApproveRequest(selectedRequest.id);
+                      setSelectedRequest(null);
+                    }}
+                    className="flex-1 bg-green-600 hover:bg-green-700"
+                  >
+                    <UserCheck className="h-4 w-4 mr-2" />
+                    Approuver
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      handleRejectRequest(selectedRequest.id);
+                      setSelectedRequest(null);
+                    }}
+                    className="flex-1 text-red-600 hover:text-red-700"
+                  >
+                    <UserX className="h-4 w-4 mr-2" />
+                    Rejeter
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/AlertManagement.tsx
+++ b/front-end-ui/client/pages/AlertManagement.tsx
@@ -1,0 +1,806 @@
+import React, { useState, useEffect } from "react";
+import DirectorSidebar from "../components/DirectorSidebar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { 
+  Select, 
+  SelectContent, 
+  SelectItem, 
+  SelectTrigger, 
+  SelectValue 
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  AlertTriangle,
+  Thermometer,
+  Droplets,
+  Wind,
+  Zap,
+  Bug,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Search,
+  MapPin,
+  Calendar,
+  Eye,
+  TrendingUp,
+  Activity
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface Alert {
+  id: string;
+  title: string;
+  description: string;
+  type: "temperature" | "humidity" | "ventilation" | "electrical" | "pest" | "other";
+  severity: "low" | "medium" | "high" | "critical";
+  status: "active" | "acknowledged" | "resolved";
+  location: {
+    zone: string;
+    greenhouse: string;
+    coordinates: { x: number; y: number };
+  };
+  timestamp: string;
+  value?: number;
+  threshold?: number;
+  unit?: string;
+  assignedTechnician?: string;
+}
+
+interface HeatMapCell {
+  x: number;
+  y: number;
+  zone: string;
+  greenhouse: string;
+  alertCount: number;
+  severity: "low" | "medium" | "high" | "critical" | "none";
+}
+
+export default function AlertManagement() {
+  const { toast } = useToast();
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [selectedSeverity, setSelectedSeverity] = useState<string>("all");
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
+  const [heatMapData, setHeatMapData] = useState<HeatMapCell[]>([]);
+  const [activeTab, setActiveTab] = useState("heatmap");
+
+  // Mock data - replace with real API calls
+  useEffect(() => {
+    const mockAlerts: Alert[] = [
+      {
+        id: "1",
+        title: "Température critique - Serre A12",
+        description: "La température a dépassé le seuil critique de 35°C",
+        type: "temperature",
+        severity: "critical",
+        status: "active",
+        location: {
+          zone: "Zone Nord",
+          greenhouse: "Serre A12",
+          coordinates: { x: 2, y: 1 }
+        },
+        timestamp: "2024-01-24T14:30:00Z",
+        value: 38.5,
+        threshold: 35,
+        unit: "°C"
+      },
+      {
+        id: "2",
+        title: "Humidité basse - Serre B08",
+        description: "Niveau d'humidité en dessous du minimum requis",
+        type: "humidity",
+        severity: "high",
+        status: "acknowledged",
+        location: {
+          zone: "Zone Est",
+          greenhouse: "Serre B08",
+          coordinates: { x: 4, y: 2 }
+        },
+        timestamp: "2024-01-24T13:15:00Z",
+        value: 35,
+        threshold: 45,
+        unit: "%",
+        assignedTechnician: "Marie Dubois"
+      },
+      {
+        id: "3",
+        title: "Ventilation défaillante - Serre C15",
+        description: "Système de ventilation ne répond pas",
+        type: "ventilation",
+        severity: "high",
+        status: "active",
+        location: {
+          zone: "Zone Ouest",
+          greenhouse: "Serre C15",
+          coordinates: { x: 1, y: 3 }
+        },
+        timestamp: "2024-01-24T12:45:00Z"
+      },
+      {
+        id: "4",
+        title: "Coupure électrique - Serre D03",
+        description: "Alimentation électrique interrompue",
+        type: "electrical",
+        severity: "critical",
+        status: "active",
+        location: {
+          zone: "Zone Sud",
+          greenhouse: "Serre D03",
+          coordinates: { x: 3, y: 4 }
+        },
+        timestamp: "2024-01-24T11:20:00Z"
+      },
+      {
+        id: "5",
+        title: "Détection parasites - Serre A05",
+        description: "Présence de pucerons détectée",
+        type: "pest",
+        severity: "medium",
+        status: "resolved",
+        location: {
+          zone: "Zone Nord",
+          greenhouse: "Serre A05",
+          coordinates: { x: 1, y: 1 }
+        },
+        timestamp: "2024-01-23T16:30:00Z",
+        assignedTechnician: "Jean Martin"
+      },
+      {
+        id: "6",
+        title: "Température élevée - Serre B12",
+        description: "Température proche du seuil d'alerte",
+        type: "temperature",
+        severity: "medium",
+        status: "active",
+        location: {
+          zone: "Zone Est",
+          greenhouse: "Serre B12",
+          coordinates: { x: 5, y: 2 }
+        },
+        timestamp: "2024-01-24T10:15:00Z",
+        value: 32,
+        threshold: 35,
+        unit: "°C"
+      }
+    ];
+
+    setAlerts(mockAlerts);
+
+    // Generate heatmap data
+    const heatMap: HeatMapCell[] = [];
+    const zones = ["Zone Nord", "Zone Est", "Zone Ouest", "Zone Sud"];
+    
+    for (let x = 1; x <= 6; x++) {
+      for (let y = 1; y <= 5; y++) {
+        const alertsInCell = mockAlerts.filter(
+          alert => alert.location.coordinates.x === x && alert.location.coordinates.y === y && alert.status === "active"
+        );
+        
+        const severity = alertsInCell.length > 0 
+          ? alertsInCell.reduce((max, alert) => {
+              const severityOrder = { low: 1, medium: 2, high: 3, critical: 4 };
+              return severityOrder[alert.severity] > severityOrder[max] ? alert.severity : max;
+            }, "low" as any)
+          : "none";
+
+        heatMap.push({
+          x,
+          y,
+          zone: zones[Math.floor((y - 1) / 2)] || "Zone Nord",
+          greenhouse: `Serre ${String.fromCharCode(65 + Math.floor((x - 1) / 2))}${String(x).padStart(2, '0')}`,
+          alertCount: alertsInCell.length,
+          severity
+        });
+      }
+    }
+    
+    setHeatMapData(heatMap);
+  }, []);
+
+  const filteredAlerts = alerts.filter(alert => {
+    const matchesSearch = alert.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         alert.location.greenhouse.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesType = selectedType === "all" || alert.type === selectedType;
+    const matchesSeverity = selectedSeverity === "all" || alert.severity === selectedSeverity;
+    const matchesStatus = selectedStatus === "all" || alert.status === selectedStatus;
+    
+    return matchesSearch && matchesType && matchesSeverity && matchesStatus;
+  });
+
+  const getTabAlerts = (tab: string) => {
+    switch (tab) {
+      case "active":
+        return alerts.filter(a => a.status === "active");
+      case "acknowledged":
+        return alerts.filter(a => a.status === "acknowledged");
+      case "resolved":
+        return alerts.filter(a => a.status === "resolved");
+      default:
+        return filteredAlerts;
+    }
+  };
+
+  const handleStatusChange = (alertId: string, newStatus: "acknowledged" | "resolved") => {
+    const updatedAlerts = alerts.map(alert =>
+      alert.id === alertId ? { ...alert, status: newStatus } : alert
+    );
+    setAlerts(updatedAlerts);
+    
+    toast({
+      title: "Statut mis à jour",
+      description: `L'alerte a été marquée comme ${newStatus === "acknowledged" ? "reconnue" : "résolue"}.`,
+    });
+  };
+
+  const getSeverityColor = (severity: string) => {
+    switch (severity) {
+      case "critical":
+        return "bg-red-100 text-red-700 border-red-200";
+      case "high":
+        return "bg-orange-100 text-orange-700 border-orange-200";
+      case "medium":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      case "low":
+        return "bg-blue-100 text-blue-700 border-blue-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "active":
+        return "bg-red-100 text-red-700 border-red-200";
+      case "acknowledged":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      case "resolved":
+        return "bg-green-100 text-green-700 border-green-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const getTypeIcon = (type: string) => {
+    switch (type) {
+      case "temperature":
+        return Thermometer;
+      case "humidity":
+        return Droplets;
+      case "ventilation":
+        return Wind;
+      case "electrical":
+        return Zap;
+      case "pest":
+        return Bug;
+      default:
+        return AlertTriangle;
+    }
+  };
+
+  const getTypeDisplayName = (type: string) => {
+    switch (type) {
+      case "temperature":
+        return "Température";
+      case "humidity":
+        return "Humidité";
+      case "ventilation":
+        return "Ventilation";
+      case "electrical":
+        return "Électrique";
+      case "pest":
+        return "Parasites";
+      default:
+        return "Autre";
+    }
+  };
+
+  const getSeverityDisplayName = (severity: string) => {
+    switch (severity) {
+      case "critical":
+        return "Critique";
+      case "high":
+        return "Élevée";
+      case "medium":
+        return "Moyenne";
+      case "low":
+        return "Basse";
+      default:
+        return severity;
+    }
+  };
+
+  const getStatusDisplayName = (status: string) => {
+    switch (status) {
+      case "active":
+        return "Active";
+      case "acknowledged":
+        return "Reconnue";
+      case "resolved":
+        return "Résolue";
+      default:
+        return status;
+    }
+  };
+
+  const getHeatMapCellColor = (severity: string) => {
+    switch (severity) {
+      case "critical":
+        return "bg-red-500";
+      case "high":
+        return "bg-orange-400";
+      case "medium":
+        return "bg-yellow-400";
+      case "low":
+        return "bg-blue-400";
+      default:
+        return "bg-gray-200";
+    }
+  };
+
+  const activeCount = alerts.filter(a => a.status === "active").length;
+  const acknowledgedCount = alerts.filter(a => a.status === "acknowledged").length;
+  const resolvedCount = alerts.filter(a => a.status === "resolved").length;
+  const criticalCount = alerts.filter(a => a.severity === "critical" && a.status === "active").length;
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Gestion des alertes
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Surveillez et gérez les alertes avec vue HeatMap
+              </p>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-red-50 border-red-200 text-red-700">
+                <AlertTriangle className="h-3 w-3 mr-1" />
+                {criticalCount} critiques
+              </Badge>
+              <Badge variant="outline" className="bg-yellow-50 border-yellow-200 text-yellow-700">
+                <Activity className="h-3 w-3 mr-1" />
+                {activeCount} actives
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Alertes actives</p>
+                    <p className="text-3xl font-bold text-red-600">{activeCount}</p>
+                  </div>
+                  <AlertTriangle className="h-8 w-8 text-red-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Reconnues</p>
+                    <p className="text-3xl font-bold text-yellow-600">{acknowledgedCount}</p>
+                  </div>
+                  <Clock className="h-8 w-8 text-yellow-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Résolues</p>
+                    <p className="text-3xl font-bold text-green-600">{resolvedCount}</p>
+                  </div>
+                  <CheckCircle className="h-8 w-8 text-green-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Critiques</p>
+                    <p className="text-3xl font-bold text-red-700">{criticalCount}</p>
+                  </div>
+                  <XCircle className="h-8 w-8 text-red-700" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Tabs */}
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-5">
+              <TabsTrigger value="heatmap">HeatMap</TabsTrigger>
+              <TabsTrigger value="all">Toutes ({alerts.length})</TabsTrigger>
+              <TabsTrigger value="active">Actives ({activeCount})</TabsTrigger>
+              <TabsTrigger value="acknowledged">Reconnues ({acknowledgedCount})</TabsTrigger>
+              <TabsTrigger value="resolved">Résolues ({resolvedCount})</TabsTrigger>
+            </TabsList>
+
+            {/* HeatMap Tab */}
+            <TabsContent value="heatmap" className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center space-x-2">
+                    <TrendingUp className="h-5 w-5" />
+                    <span>HeatMap des alertes par zone</span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    {/* Legend */}
+                    <div className="flex items-center justify-center space-x-6 p-4 bg-gray-50 rounded-lg">
+                      <div className="flex items-center space-x-2">
+                        <div className="w-4 h-4 bg-gray-200 rounded"></div>
+                        <span className="text-sm">Aucune alerte</span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-4 h-4 bg-blue-400 rounded"></div>
+                        <span className="text-sm">Basse</span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-4 h-4 bg-yellow-400 rounded"></div>
+                        <span className="text-sm">Moyenne</span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-4 h-4 bg-orange-400 rounded"></div>
+                        <span className="text-sm">Élevée</span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-4 h-4 bg-red-500 rounded"></div>
+                        <span className="text-sm">Critique</span>
+                      </div>
+                    </div>
+
+                    {/* HeatMap Grid */}
+                    <div className="flex justify-center">
+                      <div className="grid grid-cols-6 gap-2 p-6 bg-white border rounded-lg">
+                        {heatMapData.map((cell) => (
+                          <div
+                            key={`${cell.x}-${cell.y}`}
+                            className={`
+                              w-16 h-16 rounded-lg border-2 border-gray-300 cursor-pointer
+                              transition-all duration-200 hover:scale-105 hover:border-gray-500
+                              flex flex-col items-center justify-center text-xs font-medium
+                              ${getHeatMapCellColor(cell.severity)}
+                              ${cell.severity === "none" ? "text-gray-600" : "text-white"}
+                            `}
+                            title={`${cell.greenhouse} - ${cell.zone}\n${cell.alertCount} alerte(s)`}
+                          >
+                            <div className="truncate w-full text-center px-1">
+                              {cell.greenhouse.split(' ')[1]}
+                            </div>
+                            {cell.alertCount > 0 && (
+                              <div className="text-xs font-bold">
+                                {cell.alertCount}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Zone Labels */}
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+                      <div className="p-3 bg-blue-50 rounded-lg">
+                        <h4 className="font-medium text-blue-900">Zone Nord</h4>
+                        <p className="text-sm text-blue-700">Serres A01-A15</p>
+                      </div>
+                      <div className="p-3 bg-green-50 rounded-lg">
+                        <h4 className="font-medium text-green-900">Zone Est</h4>
+                        <p className="text-sm text-green-700">Serres B01-B20</p>
+                      </div>
+                      <div className="p-3 bg-purple-50 rounded-lg">
+                        <h4 className="font-medium text-purple-900">Zone Ouest</h4>
+                        <p className="text-sm text-purple-700">Serres C01-C18</p>
+                      </div>
+                      <div className="p-3 bg-orange-50 rounded-lg">
+                        <h4 className="font-medium text-orange-900">Zone Sud</h4>
+                        <p className="text-sm text-orange-700">Serres D01-D25</p>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* Alert Lists Tabs */}
+            {["all", "active", "acknowledged", "resolved"].map(tab => (
+              <TabsContent key={tab} value={tab} className="space-y-6">
+                {/* Filters */}
+                <Card>
+                  <CardContent className="p-4">
+                    <div className="flex flex-col md:flex-row gap-4">
+                      <div className="flex-1">
+                        <div className="relative">
+                          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                          <Input
+                            placeholder="Rechercher alertes..."
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            className="pl-10"
+                          />
+                        </div>
+                      </div>
+                      <Select value={selectedType} onValueChange={setSelectedType}>
+                        <SelectTrigger className="w-48">
+                          <SelectValue placeholder="Type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">Tous les types</SelectItem>
+                          <SelectItem value="temperature">Température</SelectItem>
+                          <SelectItem value="humidity">Humidité</SelectItem>
+                          <SelectItem value="ventilation">Ventilation</SelectItem>
+                          <SelectItem value="electrical">Électrique</SelectItem>
+                          <SelectItem value="pest">Parasites</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Select value={selectedSeverity} onValueChange={setSelectedSeverity}>
+                        <SelectTrigger className="w-48">
+                          <SelectValue placeholder="Sévérité" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">Toutes sévérités</SelectItem>
+                          <SelectItem value="critical">Critique</SelectItem>
+                          <SelectItem value="high">Élevée</SelectItem>
+                          <SelectItem value="medium">Moyenne</SelectItem>
+                          <SelectItem value="low">Basse</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Select value={selectedStatus} onValueChange={setSelectedStatus}>
+                        <SelectTrigger className="w-48">
+                          <SelectValue placeholder="Statut" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">Tous statuts</SelectItem>
+                          <SelectItem value="active">Active</SelectItem>
+                          <SelectItem value="acknowledged">Reconnue</SelectItem>
+                          <SelectItem value="resolved">Résolue</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Alert Cards */}
+                <div className="space-y-4">
+                  {getTabAlerts(tab).map((alert) => {
+                    const TypeIcon = getTypeIcon(alert.type);
+                    
+                    return (
+                      <Card key={alert.id} className="hover:shadow-md transition-shadow">
+                        <CardContent className="p-6">
+                          <div className="flex items-start justify-between">
+                            <div className="flex items-start space-x-4 flex-1">
+                              <div className="p-3 bg-gray-100 rounded-lg">
+                                <TypeIcon className="h-6 w-6 text-gray-600" />
+                              </div>
+                              <div className="flex-1">
+                                <div className="flex items-center space-x-3 mb-2">
+                                  <h3 className="text-lg font-semibold text-gray-900">
+                                    {alert.title}
+                                  </h3>
+                                  <Badge variant="outline" className={getSeverityColor(alert.severity)}>
+                                    {getSeverityDisplayName(alert.severity)}
+                                  </Badge>
+                                  <Badge variant="outline" className={getStatusColor(alert.status)}>
+                                    {getStatusDisplayName(alert.status)}
+                                  </Badge>
+                                  <Badge variant="outline">
+                                    {getTypeDisplayName(alert.type)}
+                                  </Badge>
+                                </div>
+                                
+                                <p className="text-gray-600 mb-3">{alert.description}</p>
+                                
+                                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-gray-600">
+                                  <div className="flex items-center">
+                                    <MapPin className="h-4 w-4 mr-1" />
+                                    {alert.location.greenhouse}
+                                  </div>
+                                  <div className="flex items-center">
+                                    <Calendar className="h-4 w-4 mr-1" />
+                                    {new Date(alert.timestamp).toLocaleString('fr-FR')}
+                                  </div>
+                                  {alert.value && alert.unit && (
+                                    <div className="flex items-center">
+                                      <TrendingUp className="h-4 w-4 mr-1" />
+                                      {alert.value}{alert.unit}
+                                      {alert.threshold && ` (seuil: ${alert.threshold}${alert.unit})`}
+                                    </div>
+                                  )}
+                                  {alert.assignedTechnician && (
+                                    <div className="flex items-center">
+                                      <Eye className="h-4 w-4 mr-1" />
+                                      {alert.assignedTechnician}
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+
+                            <div className="flex items-center space-x-2 ml-4">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setSelectedAlert(alert)}
+                              >
+                                <Eye className="h-4 w-4 mr-1" />
+                                Détails
+                              </Button>
+
+                              {alert.status === "active" && (
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleStatusChange(alert.id, "acknowledged")}
+                                  className="bg-yellow-600 hover:bg-yellow-700"
+                                >
+                                  <Clock className="h-4 w-4 mr-1" />
+                                  Reconnaître
+                                </Button>
+                              )}
+
+                              {(alert.status === "active" || alert.status === "acknowledged") && (
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleStatusChange(alert.id, "resolved")}
+                                  className="bg-green-600 hover:bg-green-700"
+                                >
+                                  <CheckCircle className="h-4 w-4 mr-1" />
+                                  Résoudre
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+
+                  {getTabAlerts(tab).length === 0 && (
+                    <Card>
+                      <CardContent className="p-12 text-center">
+                        <AlertTriangle className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                        <h3 className="text-lg font-medium text-gray-900 mb-2">
+                          Aucune alerte trouvée
+                        </h3>
+                        <p className="text-gray-600">
+                          Aucune alerte ne correspond à vos critères.
+                        </p>
+                      </CardContent>
+                    </Card>
+                  )}
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+      </div>
+
+      {/* Alert Details Modal */}
+      <Dialog open={!!selectedAlert} onOpenChange={() => setSelectedAlert(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Détails de l'alerte</DialogTitle>
+            <DialogDescription>
+              Informations complètes sur l'alerte
+            </DialogDescription>
+          </DialogHeader>
+          {selectedAlert && (
+            <div className="space-y-6">
+              <div className="flex items-center space-x-4">
+                <div className="p-4 bg-gray-100 rounded-lg">
+                  {React.createElement(getTypeIcon(selectedAlert.type), { 
+                    className: "h-8 w-8 text-gray-600" 
+                  })}
+                </div>
+                <div>
+                  <h3 className="text-xl font-semibold">{selectedAlert.title}</h3>
+                  <div className="flex items-center space-x-2 mt-1">
+                    <Badge variant="outline" className={getSeverityColor(selectedAlert.severity)}>
+                      {getSeverityDisplayName(selectedAlert.severity)}
+                    </Badge>
+                    <Badge variant="outline" className={getStatusColor(selectedAlert.status)}>
+                      {getStatusDisplayName(selectedAlert.status)}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Type d'alerte</label>
+                  <p className="mt-1">{getTypeDisplayName(selectedAlert.type)}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Horodatage</label>
+                  <p className="mt-1">{new Date(selectedAlert.timestamp).toLocaleString('fr-FR')}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-700">Localisation</label>
+                  <p className="mt-1">{selectedAlert.location.greenhouse} - {selectedAlert.location.zone}</p>
+                </div>
+                {selectedAlert.assignedTechnician && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Technicien assigné</label>
+                    <p className="mt-1">{selectedAlert.assignedTechnician}</p>
+                  </div>
+                )}
+                {selectedAlert.value && selectedAlert.unit && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Valeur mesurée</label>
+                    <p className="mt-1">{selectedAlert.value}{selectedAlert.unit}</p>
+                  </div>
+                )}
+                {selectedAlert.threshold && selectedAlert.unit && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700">Seuil d'alerte</label>
+                    <p className="mt-1">{selectedAlert.threshold}{selectedAlert.unit}</p>
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-gray-700">Description</label>
+                <p className="mt-1 text-gray-900">{selectedAlert.description}</p>
+              </div>
+
+              {(selectedAlert.status === "active" || selectedAlert.status === "acknowledged") && (
+                <div className="flex space-x-3 pt-4 border-t">
+                  {selectedAlert.status === "active" && (
+                    <Button
+                      onClick={() => {
+                        handleStatusChange(selectedAlert.id, "acknowledged");
+                        setSelectedAlert(null);
+                      }}
+                      className="flex-1 bg-yellow-600 hover:bg-yellow-700"
+                    >
+                      <Clock className="h-4 w-4 mr-2" />
+                      Reconnaître
+                    </Button>
+                  )}
+                  <Button
+                    onClick={() => {
+                      handleStatusChange(selectedAlert.id, "resolved");
+                      setSelectedAlert(null);
+                    }}
+                    className="flex-1 bg-green-600 hover:bg-green-700"
+                  >
+                    <CheckCircle className="h-4 w-4 mr-2" />
+                    Résoudre
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/DirectorDashboard.tsx
+++ b/front-end-ui/client/pages/DirectorDashboard.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import DirectorSidebar from "../components/DirectorSidebar";
+import {
+  Users,
+  Wrench,
+  AlertTriangle,
+  FileText,
+  TrendingUp,
+  TrendingDown,
+  Clock,
+  CheckCircle,
+  UserCheck,
+  Activity,
+  BarChart3,
+  Calendar
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StatCard {
+  title: string;
+  value: string | number;
+  change: string;
+  trend: "up" | "down" | "neutral";
+  icon: React.ElementType;
+  color: string;
+  description?: string;
+}
+
+export default function DirectorDashboard() {
+  const { user } = useAuth();
+  const [loading, setLoading] = useState(true);
+
+  // Mock data - replace with real API calls
+  const stats: StatCard[] = [
+    {
+      title: "Techniciens actifs",
+      value: 24,
+      change: "+2 ce mois",
+      trend: "up",
+      icon: Users,
+      color: "blue",
+      description: "Techniciens et superviseurs"
+    },
+    {
+      title: "Interventions en cours",
+      value: 18,
+      change: "+5 aujourd'hui",
+      trend: "up",
+      icon: Wrench,
+      color: "green",
+      description: "Interventions assignées"
+    },
+    {
+      title: "Alertes actives",
+      value: 7,
+      change: "-3 depuis hier",
+      trend: "down",
+      icon: AlertTriangle,
+      color: "red",
+      description: "Nécessitent attention"
+    },
+    {
+      title: "Rapports générés",
+      value: 156,
+      change: "+12 cette semaine",
+      trend: "up",
+      icon: FileText,
+      color: "purple",
+      description: "Rapports d'intervention"
+    }
+  ];
+
+  const recentActivities = [
+    {
+      id: 1,
+      type: "intervention",
+      message: "Nouvelle intervention assignée à Marie Dubois",
+      time: "Il y a 2 heures",
+      status: "info"
+    },
+    {
+      id: 2,
+      type: "alert",
+      message: "Alerte température critique - Serre B23",
+      time: "Il y a 3 heures",
+      status: "warning"
+    },
+    {
+      id: 3,
+      type: "affiliation",
+      message: "Demande d'affiliation approuvée - Jean Martin",
+      time: "Il y a 5 heures",
+      status: "success"
+    },
+    {
+      id: 4,
+      type: "report",
+      message: "Rapport d'intervention complété",
+      time: "Il y a 1 jour",
+      status: "info"
+    }
+  ];
+
+  const pendingTasks = [
+    {
+      id: 1,
+      title: "Valider 3 demandes d'affiliation",
+      priority: "high",
+      dueDate: "Aujourd'hui"
+    },
+    {
+      id: 2,
+      title: "Réviser les alertes de température",
+      priority: "medium",
+      dueDate: "Demain"
+    },
+    {
+      id: 3,
+      title: "Approuver les rapports hebdomadaires",
+      priority: "low",
+      dueDate: "Cette semaine"
+    }
+  ];
+
+  useEffect(() => {
+    // Simulate loading data
+    const timer = setTimeout(() => setLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const getStatColor = (color: string) => {
+    const colors = {
+      blue: "bg-blue-50 border-blue-200 text-blue-700",
+      green: "bg-green-50 border-green-200 text-green-700",
+      red: "bg-red-50 border-red-200 text-red-700",
+      purple: "bg-purple-50 border-purple-200 text-purple-700"
+    };
+    return colors[color as keyof typeof colors] || colors.blue;
+  };
+
+  const getIconColor = (color: string) => {
+    const colors = {
+      blue: "text-blue-600",
+      green: "text-green-600",
+      red: "text-red-600",
+      purple: "text-purple-600"
+    };
+    return colors[color as keyof typeof colors] || colors.blue;
+  };
+
+  const getTrendIcon = (trend: string) => {
+    return trend === "up" ? TrendingUp : TrendingDown;
+  };
+
+  const getActivityIcon = (type: string) => {
+    const icons = {
+      intervention: Wrench,
+      alert: AlertTriangle,
+      affiliation: UserCheck,
+      report: FileText
+    };
+    return icons[type as keyof typeof icons] || Activity;
+  };
+
+  const getPriorityColor = (priority: string) => {
+    const colors = {
+      high: "bg-red-100 text-red-700",
+      medium: "bg-yellow-100 text-yellow-700",
+      low: "bg-blue-100 text-blue-700"
+    };
+    return colors[priority as keyof typeof colors] || colors.low;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-screen bg-gray-50">
+        <DirectorSidebar />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
+            <p className="mt-4 text-gray-600">Chargement du tableau de bord...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Tableau de bord directeur
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Bienvenue, {user?.name || user?.email}
+              </p>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Badge variant="outline" className="bg-green-50 border-green-200 text-green-700">
+                <Calendar className="h-3 w-3 mr-1" />
+                {new Date().toLocaleDateString('fr-FR')}
+              </Badge>
+              <Button size="sm" className="bg-green-600 hover:bg-green-700">
+                <BarChart3 className="h-4 w-4 mr-1" />
+                Rapport général
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6 space-y-6">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {stats.map((stat, index) => {
+              const IconComponent = stat.icon;
+              const TrendIcon = getTrendIcon(stat.trend);
+              
+              return (
+                <Card key={index} className="hover:shadow-md transition-shadow">
+                  <CardContent className="p-6">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <div className={cn("p-2 rounded-lg", getStatColor(stat.color))}>
+                          <IconComponent className={cn("h-5 w-5", getIconColor(stat.color))} />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-gray-600">{stat.title}</p>
+                          <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-4 flex items-center justify-between">
+                      <div className="flex items-center space-x-1">
+                        <TrendIcon className={cn(
+                          "h-4 w-4",
+                          stat.trend === "up" ? "text-green-600" : "text-red-600"
+                        )} />
+                        <span className={cn(
+                          "text-sm font-medium",
+                          stat.trend === "up" ? "text-green-600" : "text-red-600"
+                        )}>
+                          {stat.change}
+                        </span>
+                      </div>
+                    </div>
+                    {stat.description && (
+                      <p className="text-xs text-gray-500 mt-2">{stat.description}</p>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Recent Activities */}
+            <Card className="lg:col-span-2">
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Activity className="h-5 w-5" />
+                  <span>Activités récentes</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {recentActivities.map((activity) => {
+                    const ActivityIcon = getActivityIcon(activity.type);
+                    return (
+                      <div key={activity.id} className="flex items-start space-x-3 p-3 hover:bg-gray-50 rounded-lg">
+                        <div className={cn(
+                          "p-2 rounded-full",
+                          activity.status === "warning" ? "bg-yellow-100" :
+                          activity.status === "success" ? "bg-green-100" : "bg-blue-100"
+                        )}>
+                          <ActivityIcon className={cn(
+                            "h-4 w-4",
+                            activity.status === "warning" ? "text-yellow-600" :
+                            activity.status === "success" ? "text-green-600" : "text-blue-600"
+                          )} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900">{activity.message}</p>
+                          <p className="text-xs text-gray-500">{activity.time}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Pending Tasks */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Clock className="h-5 w-5" />
+                  <span>Tâches en attente</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {pendingTasks.map((task) => (
+                    <div key={task.id} className="p-3 border border-gray-200 rounded-lg hover:border-gray-300 transition-colors">
+                      <div className="flex items-center justify-between mb-2">
+                        <Badge variant="outline" className={getPriorityColor(task.priority)}>
+                          {task.priority === "high" ? "Urgent" : 
+                           task.priority === "medium" ? "Moyen" : "Bas"}
+                        </Badge>
+                        <span className="text-xs text-gray-500">{task.dueDate}</span>
+                      </div>
+                      <p className="text-sm font-medium text-gray-900">{task.title}</p>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Quick Actions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Actions rapides</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                <Button variant="outline" className="h-20 flex flex-col space-y-2">
+                  <Users className="h-6 w-6" />
+                  <span className="text-sm">Ajouter technicien</span>
+                </Button>
+                <Button variant="outline" className="h-20 flex flex-col space-y-2">
+                  <Wrench className="h-6 w-6" />
+                  <span className="text-sm">Créer intervention</span>
+                </Button>
+                <Button variant="outline" className="h-20 flex flex-col space-y-2">
+                  <AlertTriangle className="h-6 w-6" />
+                  <span className="text-sm">Voir alertes</span>
+                </Button>
+                <Button variant="outline" className="h-20 flex flex-col space-y-2">
+                  <FileText className="h-6 w-6" />
+                  <span className="text-sm">Générer rapport</span>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/InterventionManagement.tsx
+++ b/front-end-ui/client/pages/InterventionManagement.tsx
@@ -1,0 +1,953 @@
+import React, { useState, useEffect } from "react";
+import DirectorSidebar from "../components/DirectorSidebar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogTrigger,
+  DialogFooter 
+} from "@/components/ui/dialog";
+import { 
+  Select, 
+  SelectContent, 
+  SelectItem, 
+  SelectTrigger, 
+  SelectValue 
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Wrench,
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  User,
+  Calendar,
+  MapPin,
+  Clock,
+  CheckCircle,
+  AlertTriangle,
+  Filter
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface Technician {
+  id: string;
+  name: string;
+  role: "technicien" | "technicien_sup";
+  avatar?: string;
+  status: "available" | "busy" | "unavailable";
+  currentInterventions: number;
+}
+
+interface Intervention {
+  id: string;
+  title: string;
+  description: string;
+  type: "maintenance" | "installation" | "repair" | "inspection";
+  priority: "low" | "medium" | "high" | "urgent";
+  status: "pending" | "assigned" | "in_progress" | "completed" | "cancelled";
+  location: string;
+  scheduledDate: string;
+  estimatedDuration: number; // in hours
+  assignedTechnician?: Technician;
+  createdDate: string;
+  requiredSkills?: string[];
+  notes?: string;
+}
+
+export default function InterventionManagement() {
+  const { toast } = useToast();
+  const [interventions, setInterventions] = useState<Intervention[]>([]);
+  const [technicians, setTechnicians] = useState<Technician[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedPriority, setSelectedPriority] = useState<string>("all");
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingIntervention, setEditingIntervention] = useState<Intervention | null>(null);
+  const [assignModalOpen, setAssignModalOpen] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("all");
+  
+  const [formData, setFormData] = useState({
+    title: "",
+    description: "",
+    type: "maintenance" as "maintenance" | "installation" | "repair" | "inspection",
+    priority: "medium" as "low" | "medium" | "high" | "urgent",
+    location: "",
+    scheduledDate: "",
+    estimatedDuration: 2,
+    requiredSkills: "",
+    notes: ""
+  });
+
+  // Mock data - replace with real API calls
+  useEffect(() => {
+    const mockTechnicians: Technician[] = [
+      {
+        id: "1",
+        name: "Marie Dubois",
+        role: "technicien_sup",
+        status: "available",
+        currentInterventions: 2
+      },
+      {
+        id: "2",
+        name: "Jean Martin",
+        role: "technicien",
+        status: "busy",
+        currentInterventions: 3
+      },
+      {
+        id: "3",
+        name: "Sophie Lambert",
+        role: "technicien",
+        status: "available",
+        currentInterventions: 1
+      },
+      {
+        id: "4",
+        name: "Pierre Durand",
+        role: "technicien_sup",
+        status: "unavailable",
+        currentInterventions: 0
+      }
+    ];
+
+    const mockInterventions: Intervention[] = [
+      {
+        id: "1",
+        title: "Maintenance système d'irrigation - Serre A12",
+        description: "Vérification et nettoyage des buses d'irrigation automatique",
+        type: "maintenance",
+        priority: "high",
+        status: "assigned",
+        location: "Serre A12, Zone Nord",
+        scheduledDate: "2024-01-25",
+        estimatedDuration: 3,
+        assignedTechnician: mockTechnicians[0],
+        createdDate: "2024-01-20",
+        requiredSkills: ["irrigation", "maintenance"],
+        notes: "Vérifier la pression d'eau"
+      },
+      {
+        id: "2",
+        title: "Installation capteurs température",
+        description: "Installation de nouveaux capteurs IoT pour monitoring température",
+        type: "installation",
+        priority: "medium",
+        status: "pending",
+        location: "Serre B15, Zone Est",
+        scheduledDate: "2024-01-26",
+        estimatedDuration: 4,
+        createdDate: "2024-01-21",
+        requiredSkills: ["électronique", "IoT"]
+      },
+      {
+        id: "3",
+        title: "Réparation ventilation - Serre C08",
+        description: "Moteur de ventilation défaillant, remplacment nécessaire",
+        type: "repair",
+        priority: "urgent",
+        status: "in_progress",
+        location: "Serre C08, Zone Ouest",
+        scheduledDate: "2024-01-24",
+        estimatedDuration: 2,
+        assignedTechnician: mockTechnicians[1],
+        createdDate: "2024-01-22",
+        notes: "Urgence - température critique"
+      },
+      {
+        id: "4",
+        title: "Inspection mensuelle - Zone Sud",
+        description: "Inspection de routine des équipements zone sud",
+        type: "inspection",
+        priority: "low",
+        status: "completed",
+        location: "Zone Sud - Serres D01 à D20",
+        scheduledDate: "2024-01-15",
+        estimatedDuration: 6,
+        assignedTechnician: mockTechnicians[2],
+        createdDate: "2024-01-10"
+      }
+    ];
+
+    setTechnicians(mockTechnicians);
+    setInterventions(mockInterventions);
+  }, []);
+
+  const filteredInterventions = interventions.filter(intervention => {
+    const matchesSearch = intervention.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         intervention.location.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesPriority = selectedPriority === "all" || intervention.priority === selectedPriority;
+    const matchesStatus = selectedStatus === "all" || intervention.status === selectedStatus;
+    const matchesType = selectedType === "all" || intervention.type === selectedType;
+    
+    return matchesSearch && matchesPriority && matchesStatus && matchesType;
+  });
+
+  const getTabInterventions = (tab: string) => {
+    switch (tab) {
+      case "pending":
+        return interventions.filter(i => i.status === "pending");
+      case "assigned":
+        return interventions.filter(i => i.status === "assigned");
+      case "in_progress":
+        return interventions.filter(i => i.status === "in_progress");
+      case "completed":
+        return interventions.filter(i => i.status === "completed");
+      default:
+        return filteredInterventions;
+    }
+  };
+
+  const handleCreateIntervention = () => {
+    const newIntervention: Intervention = {
+      id: Date.now().toString(),
+      ...formData,
+      status: "pending",
+      createdDate: new Date().toISOString().split('T')[0],
+      requiredSkills: formData.requiredSkills ? formData.requiredSkills.split(',').map(s => s.trim()) : []
+    };
+
+    setInterventions([...interventions, newIntervention]);
+    setIsCreateModalOpen(false);
+    resetForm();
+    
+    toast({
+      title: "Intervention créée",
+      description: `${newIntervention.title} a été créée avec succès.`,
+    });
+  };
+
+  const handleEditIntervention = (intervention: Intervention) => {
+    setEditingIntervention(intervention);
+    setFormData({
+      title: intervention.title,
+      description: intervention.description,
+      type: intervention.type,
+      priority: intervention.priority,
+      location: intervention.location,
+      scheduledDate: intervention.scheduledDate,
+      estimatedDuration: intervention.estimatedDuration,
+      requiredSkills: intervention.requiredSkills?.join(', ') || "",
+      notes: intervention.notes || ""
+    });
+  };
+
+  const handleUpdateIntervention = () => {
+    if (!editingIntervention) return;
+
+    const updatedInterventions = interventions.map(intervention =>
+      intervention.id === editingIntervention.id
+        ? { 
+            ...intervention, 
+            ...formData,
+            requiredSkills: formData.requiredSkills ? formData.requiredSkills.split(',').map(s => s.trim()) : []
+          }
+        : intervention
+    );
+
+    setInterventions(updatedInterventions);
+    setEditingIntervention(null);
+    resetForm();
+    
+    toast({
+      title: "Intervention mise à jour",
+      description: `Les informations ont été sauvegardées.`,
+    });
+  };
+
+  const handleDeleteIntervention = (id: string) => {
+    const interventionTitle = interventions.find(i => i.id === id)?.title;
+    setInterventions(interventions.filter(intervention => intervention.id !== id));
+    
+    toast({
+      title: "Intervention supprimée",
+      description: `${interventionTitle} a été supprimée.`,
+      variant: "destructive",
+    });
+  };
+
+  const handleAssignTechnician = (interventionId: string, technicianId: string) => {
+    const technician = technicians.find(t => t.id === technicianId);
+    if (!technician) return;
+
+    const updatedInterventions = interventions.map(intervention =>
+      intervention.id === interventionId
+        ? { ...intervention, assignedTechnician: technician, status: "assigned" as const }
+        : intervention
+    );
+
+    setInterventions(updatedInterventions);
+    setAssignModalOpen(null);
+    
+    toast({
+      title: "Technicien assigné",
+      description: `${technician.name} a été assigné à l'intervention.`,
+    });
+  };
+
+  const resetForm = () => {
+    setFormData({
+      title: "",
+      description: "",
+      type: "maintenance",
+      priority: "medium",
+      location: "",
+      scheduledDate: "",
+      estimatedDuration: 2,
+      requiredSkills: "",
+      notes: ""
+    });
+  };
+
+  const getPriorityColor = (priority: string) => {
+    switch (priority) {
+      case "urgent":
+        return "bg-red-100 text-red-700 border-red-200";
+      case "high":
+        return "bg-orange-100 text-orange-700 border-orange-200";
+      case "medium":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      case "low":
+        return "bg-blue-100 text-blue-700 border-blue-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "completed":
+        return "bg-green-100 text-green-700 border-green-200";
+      case "in_progress":
+        return "bg-blue-100 text-blue-700 border-blue-200";
+      case "assigned":
+        return "bg-purple-100 text-purple-700 border-purple-200";
+      case "pending":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      case "cancelled":
+        return "bg-red-100 text-red-700 border-red-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const getTypeDisplayName = (type: string) => {
+    switch (type) {
+      case "maintenance":
+        return "Maintenance";
+      case "installation":
+        return "Installation";
+      case "repair":
+        return "Réparation";
+      case "inspection":
+        return "Inspection";
+      default:
+        return type;
+    }
+  };
+
+  const getStatusDisplayName = (status: string) => {
+    switch (status) {
+      case "pending":
+        return "En attente";
+      case "assigned":
+        return "Assignée";
+      case "in_progress":
+        return "En cours";
+      case "completed":
+        return "Terminée";
+      case "cancelled":
+        return "Annulée";
+      default:
+        return status;
+    }
+  };
+
+  const getPriorityDisplayName = (priority: string) => {
+    switch (priority) {
+      case "urgent":
+        return "Urgent";
+      case "high":
+        return "Élevée";
+      case "medium":
+        return "Moyenne";
+      case "low":
+        return "Basse";
+      default:
+        return priority;
+    }
+  };
+
+  const getTechnicianStatusColor = (status: string) => {
+    switch (status) {
+      case "available":
+        return "bg-green-100 text-green-700";
+      case "busy":
+        return "bg-yellow-100 text-yellow-700";
+      case "unavailable":
+        return "bg-red-100 text-red-700";
+      default:
+        return "bg-gray-100 text-gray-700";
+    }
+  };
+
+  const pendingCount = interventions.filter(i => i.status === "pending").length;
+  const assignedCount = interventions.filter(i => i.status === "assigned").length;
+  const inProgressCount = interventions.filter(i => i.status === "in_progress").length;
+  const completedCount = interventions.filter(i => i.status === "completed").length;
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Gestion des interventions
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Cr��ez et assignez des interventions aux techniciens
+              </p>
+            </div>
+            <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+              <DialogTrigger asChild>
+                <Button className="bg-green-600 hover:bg-green-700">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Créer intervention
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>Créer une nouvelle intervention</DialogTitle>
+                </DialogHeader>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="col-span-2">
+                    <Label htmlFor="title">Titre de l'intervention</Label>
+                    <Input
+                      id="title"
+                      value={formData.title}
+                      onChange={(e) => setFormData({...formData, title: e.target.value})}
+                      placeholder="Ex: Maintenance système d'irrigation"
+                    />
+                  </div>
+                  <div className="col-span-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      value={formData.description}
+                      onChange={(e) => setFormData({...formData, description: e.target.value})}
+                      placeholder="Description détaillée de l'intervention"
+                      rows={3}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="type">Type</Label>
+                    <Select value={formData.type} onValueChange={(value: any) => setFormData({...formData, type: value})}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="maintenance">Maintenance</SelectItem>
+                        <SelectItem value="installation">Installation</SelectItem>
+                        <SelectItem value="repair">Réparation</SelectItem>
+                        <SelectItem value="inspection">Inspection</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="priority">Priorité</Label>
+                    <Select value={formData.priority} onValueChange={(value: any) => setFormData({...formData, priority: value})}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="low">Basse</SelectItem>
+                        <SelectItem value="medium">Moyenne</SelectItem>
+                        <SelectItem value="high">Élevée</SelectItem>
+                        <SelectItem value="urgent">Urgent</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="location">Localisation</Label>
+                    <Input
+                      id="location"
+                      value={formData.location}
+                      onChange={(e) => setFormData({...formData, location: e.target.value})}
+                      placeholder="Ex: Serre A12, Zone Nord"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="scheduledDate">Date prévue</Label>
+                    <Input
+                      id="scheduledDate"
+                      type="date"
+                      value={formData.scheduledDate}
+                      onChange={(e) => setFormData({...formData, scheduledDate: e.target.value})}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="estimatedDuration">Durée estimée (heures)</Label>
+                    <Input
+                      id="estimatedDuration"
+                      type="number"
+                      min="1"
+                      max="24"
+                      value={formData.estimatedDuration}
+                      onChange={(e) => setFormData({...formData, estimatedDuration: parseInt(e.target.value)})}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="requiredSkills">Compétences requises</Label>
+                    <Input
+                      id="requiredSkills"
+                      value={formData.requiredSkills}
+                      onChange={(e) => setFormData({...formData, requiredSkills: e.target.value})}
+                      placeholder="irrigation, électronique, IoT (séparées par virgules)"
+                    />
+                  </div>
+                  <div className="col-span-2">
+                    <Label htmlFor="notes">Notes</Label>
+                    <Textarea
+                      id="notes"
+                      value={formData.notes}
+                      onChange={(e) => setFormData({...formData, notes: e.target.value})}
+                      placeholder="Notes additionnelles"
+                      rows={2}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => {setIsCreateModalOpen(false); resetForm();}}>
+                    Annuler
+                  </Button>
+                  <Button onClick={handleCreateIntervention}>
+                    Créer
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">En attente</p>
+                    <p className="text-3xl font-bold text-yellow-600">{pendingCount}</p>
+                  </div>
+                  <Clock className="h-8 w-8 text-yellow-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Assignées</p>
+                    <p className="text-3xl font-bold text-purple-600">{assignedCount}</p>
+                  </div>
+                  <User className="h-8 w-8 text-purple-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">En cours</p>
+                    <p className="text-3xl font-bold text-blue-600">{inProgressCount}</p>
+                  </div>
+                  <Wrench className="h-8 w-8 text-blue-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Terminées</p>
+                    <p className="text-3xl font-bold text-green-600">{completedCount}</p>
+                  </div>
+                  <CheckCircle className="h-8 w-8 text-green-600" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Filters */}
+          <Card className="mb-6">
+            <CardContent className="p-4">
+              <div className="flex flex-col md:flex-row gap-4">
+                <div className="flex-1">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                    <Input
+                      placeholder="Rechercher interventions..."
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+                <Select value={selectedType} onValueChange={setSelectedType}>
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Tous les types</SelectItem>
+                    <SelectItem value="maintenance">Maintenance</SelectItem>
+                    <SelectItem value="installation">Installation</SelectItem>
+                    <SelectItem value="repair">Réparation</SelectItem>
+                    <SelectItem value="inspection">Inspection</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={selectedPriority} onValueChange={setSelectedPriority}>
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Priorité" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Toutes priorités</SelectItem>
+                    <SelectItem value="urgent">Urgent</SelectItem>
+                    <SelectItem value="high">Élevée</SelectItem>
+                    <SelectItem value="medium">Moyenne</SelectItem>
+                    <SelectItem value="low">Basse</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={selectedStatus} onValueChange={setSelectedStatus}>
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Statut" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Tous statuts</SelectItem>
+                    <SelectItem value="pending">En attente</SelectItem>
+                    <SelectItem value="assigned">Assignée</SelectItem>
+                    <SelectItem value="in_progress">En cours</SelectItem>
+                    <SelectItem value="completed">Terminée</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Tabs */}
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-5">
+              <TabsTrigger value="all">Toutes ({interventions.length})</TabsTrigger>
+              <TabsTrigger value="pending">En attente ({pendingCount})</TabsTrigger>
+              <TabsTrigger value="assigned">Assignées ({assignedCount})</TabsTrigger>
+              <TabsTrigger value="in_progress">En cours ({inProgressCount})</TabsTrigger>
+              <TabsTrigger value="completed">Terminées ({completedCount})</TabsTrigger>
+            </TabsList>
+
+            {["all", "pending", "assigned", "in_progress", "completed"].map(tab => (
+              <TabsContent key={tab} value={tab} className="space-y-4">
+                {getTabInterventions(tab).map((intervention) => (
+                  <Card key={intervention.id} className="hover:shadow-md transition-shadow">
+                    <CardContent className="p-6">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center space-x-3 mb-3">
+                            <h3 className="text-lg font-semibold text-gray-900">
+                              {intervention.title}
+                            </h3>
+                            <Badge variant="outline" className={getPriorityColor(intervention.priority)}>
+                              {getPriorityDisplayName(intervention.priority)}
+                            </Badge>
+                            <Badge variant="outline" className={getStatusColor(intervention.status)}>
+                              {getStatusDisplayName(intervention.status)}
+                            </Badge>
+                            <Badge variant="outline">
+                              {getTypeDisplayName(intervention.type)}
+                            </Badge>
+                          </div>
+                          
+                          <p className="text-gray-600 mb-3">{intervention.description}</p>
+                          
+                          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-gray-600">
+                            <div className="flex items-center">
+                              <MapPin className="h-4 w-4 mr-1" />
+                              {intervention.location}
+                            </div>
+                            <div className="flex items-center">
+                              <Calendar className="h-4 w-4 mr-1" />
+                              {new Date(intervention.scheduledDate).toLocaleDateString('fr-FR')}
+                            </div>
+                            <div className="flex items-center">
+                              <Clock className="h-4 w-4 mr-1" />
+                              {intervention.estimatedDuration}h estimées
+                            </div>
+                            {intervention.assignedTechnician && (
+                              <div className="flex items-center">
+                                <User className="h-4 w-4 mr-1" />
+                                {intervention.assignedTechnician.name}
+                              </div>
+                            )}
+                          </div>
+
+                          {intervention.requiredSkills && intervention.requiredSkills.length > 0 && (
+                            <div className="mt-3">
+                              <div className="flex flex-wrap gap-1">
+                                {intervention.requiredSkills.map((skill, index) => (
+                                  <Badge key={index} variant="secondary" className="text-xs">
+                                    {skill}
+                                  </Badge>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+
+                        <div className="flex items-center space-x-2 ml-4">
+                          {intervention.status === "pending" && (
+                            <Dialog open={assignModalOpen === intervention.id} onOpenChange={(open) => setAssignModalOpen(open ? intervention.id : null)}>
+                              <DialogTrigger asChild>
+                                <Button size="sm" className="bg-blue-600 hover:bg-blue-700">
+                                  <User className="h-4 w-4 mr-1" />
+                                  Assigner
+                                </Button>
+                              </DialogTrigger>
+                              <DialogContent>
+                                <DialogHeader>
+                                  <DialogTitle>Assigner un technicien</DialogTitle>
+                                </DialogHeader>
+                                <div className="space-y-4">
+                                  <h4 className="font-medium">Techniciens disponibles</h4>
+                                  {technicians.map((technician) => (
+                                    <div key={technician.id} className="flex items-center justify-between p-3 border rounded-lg">
+                                      <div className="flex items-center space-x-3">
+                                        <Avatar>
+                                          <AvatarImage src={technician.avatar} />
+                                          <AvatarFallback>
+                                            {technician.name.split(' ').map(n => n[0]).join('')}
+                                          </AvatarFallback>
+                                        </Avatar>
+                                        <div>
+                                          <p className="font-medium">{technician.name}</p>
+                                          <div className="flex items-center space-x-2">
+                                            <Badge variant="outline">
+                                              {technician.role === "technicien_sup" ? "Technicien Sup." : "Technicien"}
+                                            </Badge>
+                                            <Badge variant="outline" className={getTechnicianStatusColor(technician.status)}>
+                                              {technician.status === "available" ? "Disponible" : 
+                                               technician.status === "busy" ? "Occupé" : "Indisponible"}
+                                            </Badge>
+                                          </div>
+                                          <p className="text-xs text-gray-500">
+                                            {technician.currentInterventions} intervention(s) en cours
+                                          </p>
+                                        </div>
+                                      </div>
+                                      <Button
+                                        size="sm"
+                                        disabled={technician.status === "unavailable"}
+                                        onClick={() => handleAssignTechnician(intervention.id, technician.id)}
+                                      >
+                                        Assigner
+                                      </Button>
+                                    </div>
+                                  ))}
+                                </div>
+                              </DialogContent>
+                            </Dialog>
+                          )}
+
+                          <Dialog open={editingIntervention?.id === intervention.id} onOpenChange={(open) => !open && setEditingIntervention(null)}>
+                            <DialogTrigger asChild>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => handleEditIntervention(intervention)}
+                              >
+                                <Edit className="h-4 w-4" />
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent className="sm:max-w-2xl">
+                              <DialogHeader>
+                                <DialogTitle>Modifier l'intervention</DialogTitle>
+                              </DialogHeader>
+                              <div className="grid grid-cols-2 gap-4">
+                                <div className="col-span-2">
+                                  <Label htmlFor="edit-title">Titre</Label>
+                                  <Input
+                                    id="edit-title"
+                                    value={formData.title}
+                                    onChange={(e) => setFormData({...formData, title: e.target.value})}
+                                  />
+                                </div>
+                                <div className="col-span-2">
+                                  <Label htmlFor="edit-description">Description</Label>
+                                  <Textarea
+                                    id="edit-description"
+                                    value={formData.description}
+                                    onChange={(e) => setFormData({...formData, description: e.target.value})}
+                                    rows={3}
+                                  />
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-type">Type</Label>
+                                  <Select value={formData.type} onValueChange={(value: any) => setFormData({...formData, type: value})}>
+                                    <SelectTrigger>
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="maintenance">Maintenance</SelectItem>
+                                      <SelectItem value="installation">Installation</SelectItem>
+                                      <SelectItem value="repair">Réparation</SelectItem>
+                                      <SelectItem value="inspection">Inspection</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-priority">Priorité</Label>
+                                  <Select value={formData.priority} onValueChange={(value: any) => setFormData({...formData, priority: value})}>
+                                    <SelectTrigger>
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="low">Basse</SelectItem>
+                                      <SelectItem value="medium">Moyenne</SelectItem>
+                                      <SelectItem value="high">Élevée</SelectItem>
+                                      <SelectItem value="urgent">Urgent</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-location">Localisation</Label>
+                                  <Input
+                                    id="edit-location"
+                                    value={formData.location}
+                                    onChange={(e) => setFormData({...formData, location: e.target.value})}
+                                  />
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-scheduledDate">Date prévue</Label>
+                                  <Input
+                                    id="edit-scheduledDate"
+                                    type="date"
+                                    value={formData.scheduledDate}
+                                    onChange={(e) => setFormData({...formData, scheduledDate: e.target.value})}
+                                  />
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-estimatedDuration">Durée estimée (heures)</Label>
+                                  <Input
+                                    id="edit-estimatedDuration"
+                                    type="number"
+                                    min="1"
+                                    max="24"
+                                    value={formData.estimatedDuration}
+                                    onChange={(e) => setFormData({...formData, estimatedDuration: parseInt(e.target.value)})}
+                                  />
+                                </div>
+                                <div>
+                                  <Label htmlFor="edit-requiredSkills">Compétences requises</Label>
+                                  <Input
+                                    id="edit-requiredSkills"
+                                    value={formData.requiredSkills}
+                                    onChange={(e) => setFormData({...formData, requiredSkills: e.target.value})}
+                                    placeholder="séparées par virgules"
+                                  />
+                                </div>
+                                <div className="col-span-2">
+                                  <Label htmlFor="edit-notes">Notes</Label>
+                                  <Textarea
+                                    id="edit-notes"
+                                    value={formData.notes}
+                                    onChange={(e) => setFormData({...formData, notes: e.target.value})}
+                                    rows={2}
+                                  />
+                                </div>
+                              </div>
+                              <DialogFooter>
+                                <Button variant="outline" onClick={() => setEditingIntervention(null)}>
+                                  Annuler
+                                </Button>
+                                <Button onClick={handleUpdateIntervention}>
+                                  Sauvegarder
+                                </Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
+
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="outline" size="sm" className="text-red-600 hover:text-red-700">
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Supprimer l'intervention</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Êtes-vous sûr de vouloir supprimer cette intervention ? 
+                                  Cette action est irréversible.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => handleDeleteIntervention(intervention.id)}
+                                  className="bg-red-600 hover:bg-red-700"
+                                >
+                                  Supprimer
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+
+                {getTabInterventions(tab).length === 0 && (
+                  <Card>
+                    <CardContent className="p-12 text-center">
+                      <Wrench className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                      <h3 className="text-lg font-medium text-gray-900 mb-2">
+                        Aucune intervention trouvée
+                      </h3>
+                      <p className="text-gray-600">
+                        Aucune intervention ne correspond à vos critères.
+                      </p>
+                    </CardContent>
+                  </Card>
+                )}
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/Profile.tsx
+++ b/front-end-ui/client/pages/Profile.tsx
@@ -1,0 +1,245 @@
+import React, { useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import PageHeader from "../components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { User, Mail, Shield, ArrowLeft, Save } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+export default function Profile() {
+  const { user, updateUserProfile } = useAuth();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState({
+    name: user?.name || "",
+    email: user?.email || "",
+  });
+
+  const handleSave = async () => {
+    try {
+      // You would typically call an API here to update the user profile
+      // For now, we'll just show a success message
+      toast({
+        title: "Profil mis à jour",
+        description: "Vos informations ont été sauvegardées avec succès.",
+      });
+      setIsEditing(false);
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: "Une erreur est survenue lors de la mise à jour.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({
+      name: user?.name || "",
+      email: user?.email || "",
+    });
+    setIsEditing(false);
+  };
+
+  const getRoleDisplayName = (role?: string) => {
+    switch (role) {
+      case "technicien":
+        return "Technicien";
+      case "technicien_sup":
+        return "Technicien Supérieur";
+      case "directeur":
+        return "Directeur";
+      default:
+        return "Non défini";
+    }
+  };
+
+  const getRoleColor = (role?: string) => {
+    switch (role) {
+      case "technicien":
+        return "bg-blue-50 border-blue-200 text-blue-700";
+      case "technicien_sup":
+        return "bg-purple-50 border-purple-200 text-purple-700";
+      case "directeur":
+        return "bg-green-50 border-green-200 text-green-700";
+      default:
+        return "bg-gray-50 border-gray-200 text-gray-700";
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <PageHeader
+        title="Mon Profil"
+        subtitle="Gérez vos informations personnelles"
+        userRole={user?.role as any}
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate(-1)}
+            className="flex items-center space-x-1"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Retour</span>
+          </Button>
+        }
+      />
+
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="grid gap-6">
+          {/* Profile Information Card */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-blue-100 rounded-full">
+                  <User className="h-6 w-6 text-blue-600" />
+                </div>
+                <div>
+                  <CardTitle>Informations personnelles</CardTitle>
+                  <p className="text-sm text-gray-600">
+                    Vos informations de base et contact
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant={isEditing ? "outline" : "default"}
+                size="sm"
+                onClick={() => setIsEditing(!isEditing)}
+              >
+                {isEditing ? "Annuler" : "Modifier"}
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Nom complet</Label>
+                  {isEditing ? (
+                    <Input
+                      id="name"
+                      value={formData.name}
+                      onChange={(e) =>
+                        setFormData({ ...formData, name: e.target.value })
+                      }
+                      placeholder="Votre nom complet"
+                    />
+                  ) : (
+                    <div className="flex items-center space-x-2">
+                      <User className="h-4 w-4 text-gray-400" />
+                      <span className="text-gray-900">
+                        {user?.name || "Non renseigné"}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="email">Adresse e-mail</Label>
+                  {isEditing ? (
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) =>
+                        setFormData({ ...formData, email: e.target.value })
+                      }
+                      placeholder="votre@email.com"
+                    />
+                  ) : (
+                    <div className="flex items-center space-x-2">
+                      <Mail className="h-4 w-4 text-gray-400" />
+                      <span className="text-gray-900">{user?.email}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {isEditing && (
+                <>
+                  <Separator />
+                  <div className="flex justify-end space-x-2">
+                    <Button variant="outline" onClick={handleCancel}>
+                      Annuler
+                    </Button>
+                    <Button onClick={handleSave} className="flex items-center space-x-1">
+                      <Save className="h-4 w-4" />
+                      <span>Sauvegarder</span>
+                    </Button>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Role and Status Card */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-green-100 rounded-full">
+                  <Shield className="h-6 w-6 text-green-600" />
+                </div>
+                <div>
+                  <CardTitle>Rôle et statut</CardTitle>
+                  <p className="text-sm text-gray-600">
+                    Votre rôle dans l'organisation
+                  </p>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>Rôle</Label>
+                  <Badge
+                    variant="outline"
+                    className={getRoleColor(user?.role)}
+                  >
+                    {getRoleDisplayName(user?.role)}
+                  </Badge>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Statut du compte</Label>
+                  <div className="flex items-center space-x-2">
+                    <Badge
+                      variant={user?.setup_completed ? "default" : "secondary"}
+                      className={
+                        user?.setup_completed
+                          ? "bg-green-50 border-green-200 text-green-700"
+                          : "bg-yellow-50 border-yellow-200 text-yellow-700"
+                      }
+                    >
+                      {user?.setup_completed ? "Configuré" : "Configuration incomplète"}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+
+              {user?.role === "directeur" && (
+                <div className="space-y-2">
+                  <Label>Validation directeur</Label>
+                  <Badge
+                    variant={user?.directeur_valide ? "default" : "secondary"}
+                    className={
+                      user?.directeur_valide
+                        ? "bg-green-50 border-green-200 text-green-700"
+                        : "bg-red-50 border-red-200 text-red-700"
+                    }
+                  >
+                    {user?.directeur_valide ? "Validé" : "En attente de validation"}
+                  </Badge>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/ReportManagement.tsx
+++ b/front-end-ui/client/pages/ReportManagement.tsx
@@ -1,0 +1,1094 @@
+import React, { useState, useEffect } from "react";
+import DirectorSidebar from "../components/DirectorSidebar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogTrigger,
+  DialogFooter 
+} from "@/components/ui/dialog";
+import { 
+  Select, 
+  SelectContent, 
+  SelectItem, 
+  SelectTrigger, 
+  SelectValue 
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  FileText,
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  Download,
+  Eye,
+  FolderPlus,
+  Folder,
+  Calendar,
+  User,
+  Filter,
+  Save,
+  FileDown,
+  Printer,
+  Share
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface Report {
+  id: string;
+  title: string;
+  content: string;
+  type: "intervention" | "inspection" | "maintenance" | "incident" | "monthly" | "annual";
+  status: "draft" | "completed" | "published" | "archived";
+  folderId: string;
+  createdBy: string;
+  createdDate: string;
+  lastModified: string;
+  tags?: string[];
+  attachments?: string[];
+  metadata?: {
+    location?: string;
+    technician?: string;
+    interventionId?: string;
+  };
+}
+
+interface Folder {
+  id: string;
+  name: string;
+  description?: string;
+  parentId?: string;
+  createdDate: string;
+  reportCount: number;
+}
+
+// Simple WYSIWYG Editor Component
+const WYSIWYGEditor = ({ content, onChange }: { content: string; onChange: (content: string) => void }) => {
+  const [editorContent, setEditorContent] = useState(content);
+
+  useEffect(() => {
+    setEditorContent(content);
+  }, [content]);
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newContent = e.target.value;
+    setEditorContent(newContent);
+    onChange(newContent);
+  };
+
+  const insertText = (before: string, after: string = "") => {
+    const textarea = document.getElementById("wysiwyg-editor") as HTMLTextAreaElement;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selectedText = editorContent.substring(start, end);
+    const newContent = 
+      editorContent.substring(0, start) + 
+      before + selectedText + after + 
+      editorContent.substring(end);
+    
+    setEditorContent(newContent);
+    onChange(newContent);
+  };
+
+  return (
+    <div className="border rounded-lg">
+      {/* Toolbar */}
+      <div className="border-b p-2 flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("**", "**")}
+          title="Gras"
+        >
+          <strong>B</strong>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("*", "*")}
+          title="Italique"
+        >
+          <em>I</em>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("# ", "")}
+          title="Titre 1"
+        >
+          H1
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("## ", "")}
+          title="Titre 2"
+        >
+          H2
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("- ", "")}
+          title="Liste"
+        >
+          Liste
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => insertText("`", "`")}
+          title="Code"
+        >
+          Code
+        </Button>
+      </div>
+      
+      {/* Editor */}
+      <Textarea
+        id="wysiwyg-editor"
+        value={editorContent}
+        onChange={handleContentChange}
+        placeholder="Commencez à écrire votre rapport..."
+        className="border-0 resize-none rounded-t-none"
+        rows={20}
+      />
+    </div>
+  );
+};
+
+// PDF Viewer Component (simplified)
+const PDFViewer = ({ reportContent, title }: { reportContent: string; title: string }) => {
+  const formatContentForPDF = (content: string) => {
+    // Simple markdown-like formatting to HTML
+    return content
+      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.*?)\*/g, '<em>$1</em>')
+      .replace(/^# (.*$)/gm, '<h1>$1</h1>')
+      .replace(/^## (.*$)/gm, '<h2>$1</h2>')
+      .replace(/^- (.*$)/gm, '<li>$1</li>')
+      .replace(/`(.*?)`/g, '<code>$1</code>')
+      .replace(/\n/g, '<br>');
+  };
+
+  return (
+    <div className="bg-white p-8 shadow-lg border rounded-lg max-h-96 overflow-y-auto">
+      <div className="text-center mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+        <p className="text-gray-600">Généré le {new Date().toLocaleDateString('fr-FR')}</p>
+      </div>
+      
+      <div 
+        className="prose max-w-none"
+        dangerouslySetInnerHTML={{ __html: formatContentForPDF(reportContent) }}
+      />
+    </div>
+  );
+};
+
+export default function ReportManagement() {
+  const { toast } = useToast();
+  const [reports, setReports] = useState<Report[]>([]);
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
+  const [selectedFolder, setSelectedFolder] = useState<string>("all");
+  const [isCreateReportModalOpen, setIsCreateReportModalOpen] = useState(false);
+  const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
+  const [editingReport, setEditingReport] = useState<Report | null>(null);
+  const [viewingReport, setViewingReport] = useState<Report | null>(null);
+  const [activeTab, setActiveTab] = useState("reports");
+  
+  const [reportForm, setReportForm] = useState({
+    title: "",
+    content: "",
+    type: "intervention" as "intervention" | "inspection" | "maintenance" | "incident" | "monthly" | "annual",
+    folderId: "",
+    tags: "",
+    location: "",
+    technician: "",
+    interventionId: ""
+  });
+
+  const [folderForm, setFolderForm] = useState({
+    name: "",
+    description: "",
+    parentId: ""
+  });
+
+  // Mock data - replace with real API calls
+  useEffect(() => {
+    const mockFolders: Folder[] = [
+      {
+        id: "1",
+        name: "Rapports d'intervention",
+        description: "Rapports détaillés des interventions techniques",
+        createdDate: "2024-01-01",
+        reportCount: 15
+      },
+      {
+        id: "2",
+        name: "Inspections mensuelles",
+        description: "Rapports d'inspection régulière des installations",
+        createdDate: "2024-01-01",
+        reportCount: 8
+      },
+      {
+        id: "3",
+        name: "Maintenance préventive",
+        description: "Documentation des opérations de maintenance",
+        createdDate: "2024-01-01",
+        reportCount: 12
+      },
+      {
+        id: "4",
+        name: "Rapports annuels",
+        description: "Synthèses et bilans annuels",
+        createdDate: "2024-01-01",
+        reportCount: 3
+      }
+    ];
+
+    const mockReports: Report[] = [
+      {
+        id: "1",
+        title: "Rapport d'intervention - Serre A12",
+        content: "# Rapport d'intervention - Maintenance système d'irrigation\n\n## Contexte\nIntervention programmée pour la maintenance du système d'irrigation de la serre A12.\n\n## Actions réalisées\n- Vérification des buses d'irrigation\n- Nettoyage des filtres\n- Test de pression\n- Remplacement de 3 buses défectueuses\n\n## Observations\nSystème fonctionnel après intervention. **Recommandation** : programmer une maintenance dans 3 mois.\n\n## Matériel utilisé\n- 3 buses d'irrigation (réf. BUS-001)\n- Joints d'étanchéité\n- Produit nettoyant spécialisé",
+        type: "intervention",
+        status: "completed",
+        folderId: "1",
+        createdBy: "Marie Dubois",
+        createdDate: "2024-01-24",
+        lastModified: "2024-01-24",
+        tags: ["irrigation", "maintenance", "serre-a12"],
+        metadata: {
+          location: "Serre A12, Zone Nord",
+          technician: "Marie Dubois",
+          interventionId: "INT-2024-001"
+        }
+      },
+      {
+        id: "2",
+        title: "Inspection mensuelle - Zone Est",
+        content: "# Inspection mensuelle - Zone Est\n\n## Périmètre\nInspection de routine des serres B01 à B20 de la zone Est.\n\n## État général\n- **Serres B01-B10** : État satisfaisant\n- **Serres B11-B15** : Quelques anomalies mineures détectées\n- **Serres B16-B20** : État excellent\n\n## Anomalies détectées\n1. **Serre B12** : Ventilation bruyante\n2. **Serre B14** : Température légèrement élevée\n3. **Serre B15** : Fuite mineure dans le système d'irrigation\n\n## Actions recommandées\n- Programmer maintenance ventilation B12\n- Vérifier régulation température B14\n- Réparer fuite B15 (urgent)",
+        type: "inspection",
+        status: "published",
+        folderId: "2",
+        createdBy: "Jean Martin",
+        createdDate: "2024-01-22",
+        lastModified: "2024-01-23",
+        tags: ["inspection", "zone-est", "mensuel"],
+        metadata: {
+          location: "Zone Est - Serres B01 à B20"
+        }
+      },
+      {
+        id: "3",
+        title: "Maintenance préventive - Système électrique",
+        content: "# Maintenance préventive - Système électrique\n\n## Objectif\nMaintenance préventive trimestrielle du système électrique principal.\n\n## Contrôles effectués\n- Vérification des tableaux électriques\n- Test des disjoncteurs\n- Contrôle de l'isolement\n- Vérification des connexions\n\n## Résultats\nTous les tests sont **conformes** aux normes de sécurité.\n\n## Actions préventives\n- Resserrage de 5 connexions\n- Nettoyage des tableaux\n- Mise à jour de la documentation technique",
+        type: "maintenance",
+        status: "draft",
+        folderId: "3",
+        createdBy: "Sophie Lambert",
+        createdDate: "2024-01-20",
+        lastModified: "2024-01-21",
+        tags: ["électrique", "préventif", "sécurité"]
+      }
+    ];
+
+    setFolders(mockFolders);
+    setReports(mockReports);
+  }, []);
+
+  const filteredReports = reports.filter(report => {
+    const matchesSearch = report.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         report.content.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesType = selectedType === "all" || report.type === selectedType;
+    const matchesStatus = selectedStatus === "all" || report.status === selectedStatus;
+    const matchesFolder = selectedFolder === "all" || report.folderId === selectedFolder;
+    
+    return matchesSearch && matchesType && matchesStatus && matchesFolder;
+  });
+
+  const handleCreateReport = () => {
+    const newReport: Report = {
+      id: Date.now().toString(),
+      ...reportForm,
+      status: "draft",
+      createdBy: "Directeur", // Would be from auth context
+      createdDate: new Date().toISOString().split('T')[0],
+      lastModified: new Date().toISOString().split('T')[0],
+      tags: reportForm.tags ? reportForm.tags.split(',').map(tag => tag.trim()) : [],
+      metadata: {
+        location: reportForm.location || undefined,
+        technician: reportForm.technician || undefined,
+        interventionId: reportForm.interventionId || undefined
+      }
+    };
+
+    setReports([...reports, newReport]);
+    setIsCreateReportModalOpen(false);
+    resetReportForm();
+    
+    toast({
+      title: "Rapport créé",
+      description: `${newReport.title} a été créé avec succès.`,
+    });
+  };
+
+  const handleCreateFolder = () => {
+    const newFolder: Folder = {
+      id: Date.now().toString(),
+      ...folderForm,
+      createdDate: new Date().toISOString().split('T')[0],
+      reportCount: 0
+    };
+
+    setFolders([...folders, newFolder]);
+    setIsCreateFolderModalOpen(false);
+    setFolderForm({ name: "", description: "", parentId: "" });
+    
+    toast({
+      title: "Dossier créé",
+      description: `${newFolder.name} a été créé avec succès.`,
+    });
+  };
+
+  const handleEditReport = (report: Report) => {
+    setEditingReport(report);
+    setReportForm({
+      title: report.title,
+      content: report.content,
+      type: report.type,
+      folderId: report.folderId,
+      tags: report.tags?.join(', ') || "",
+      location: report.metadata?.location || "",
+      technician: report.metadata?.technician || "",
+      interventionId: report.metadata?.interventionId || ""
+    });
+  };
+
+  const handleUpdateReport = () => {
+    if (!editingReport) return;
+
+    const updatedReports = reports.map(report =>
+      report.id === editingReport.id
+        ? { 
+            ...report, 
+            ...reportForm,
+            lastModified: new Date().toISOString().split('T')[0],
+            tags: reportForm.tags ? reportForm.tags.split(',').map(tag => tag.trim()) : [],
+            metadata: {
+              location: reportForm.location || undefined,
+              technician: reportForm.technician || undefined,
+              interventionId: reportForm.interventionId || undefined
+            }
+          }
+        : report
+    );
+
+    setReports(updatedReports);
+    setEditingReport(null);
+    resetReportForm();
+    
+    toast({
+      title: "Rapport mis à jour",
+      description: `Les modifications ont été sauvegardées.`,
+    });
+  };
+
+  const handleDeleteReport = (id: string) => {
+    const reportTitle = reports.find(r => r.id === id)?.title;
+    setReports(reports.filter(report => report.id !== id));
+    
+    toast({
+      title: "Rapport supprimé",
+      description: `${reportTitle} a été supprimé.`,
+      variant: "destructive",
+    });
+  };
+
+  const handleStatusChange = (reportId: string, newStatus: "draft" | "completed" | "published" | "archived") => {
+    const updatedReports = reports.map(report =>
+      report.id === reportId ? { ...report, status: newStatus } : report
+    );
+    setReports(updatedReports);
+    
+    toast({
+      title: "Statut mis à jour",
+      description: `Le rapport a été marqué comme ${getStatusDisplayName(newStatus)}.`,
+    });
+  };
+
+  const resetReportForm = () => {
+    setReportForm({
+      title: "",
+      content: "",
+      type: "intervention",
+      folderId: "",
+      tags: "",
+      location: "",
+      technician: "",
+      interventionId: ""
+    });
+  };
+
+  const getTypeDisplayName = (type: string) => {
+    switch (type) {
+      case "intervention":
+        return "Intervention";
+      case "inspection":
+        return "Inspection";
+      case "maintenance":
+        return "Maintenance";
+      case "incident":
+        return "Incident";
+      case "monthly":
+        return "Mensuel";
+      case "annual":
+        return "Annuel";
+      default:
+        return type;
+    }
+  };
+
+  const getStatusDisplayName = (status: string) => {
+    switch (status) {
+      case "draft":
+        return "Brouillon";
+      case "completed":
+        return "Terminé";
+      case "published":
+        return "Publié";
+      case "archived":
+        return "Archivé";
+      default:
+        return status;
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "draft":
+        return "bg-gray-100 text-gray-700 border-gray-200";
+      case "completed":
+        return "bg-blue-100 text-blue-700 border-blue-200";
+      case "published":
+        return "bg-green-100 text-green-700 border-green-200";
+      case "archived":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const getTypeColor = (type: string) => {
+    switch (type) {
+      case "intervention":
+        return "bg-blue-50 text-blue-700";
+      case "inspection":
+        return "bg-green-50 text-green-700";
+      case "maintenance":
+        return "bg-purple-50 text-purple-700";
+      case "incident":
+        return "bg-red-50 text-red-700";
+      case "monthly":
+        return "bg-orange-50 text-orange-700";
+      case "annual":
+        return "bg-indigo-50 text-indigo-700";
+      default:
+        return "bg-gray-50 text-gray-700";
+    }
+  };
+
+  const exportToPDF = (report: Report) => {
+    // In a real implementation, you would use a PDF library like jsPDF or react-pdf
+    toast({
+      title: "Export PDF",
+      description: `${report.title} sera exporté en PDF.`,
+    });
+  };
+
+  const draftCount = reports.filter(r => r.status === "draft").length;
+  const completedCount = reports.filter(r => r.status === "completed").length;
+  const publishedCount = reports.filter(r => r.status === "published").length;
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Gestion des rapports
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Créez, organisez et consultez vos rapports
+              </p>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Dialog open={isCreateFolderModalOpen} onOpenChange={setIsCreateFolderModalOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="outline">
+                    <FolderPlus className="h-4 w-4 mr-2" />
+                    Nouveau dossier
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="sm:max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>Créer un nouveau dossier</DialogTitle>
+                  </DialogHeader>
+                  <div className="space-y-4">
+                    <div>
+                      <Label htmlFor="folder-name">Nom du dossier</Label>
+                      <Input
+                        id="folder-name"
+                        value={folderForm.name}
+                        onChange={(e) => setFolderForm({...folderForm, name: e.target.value})}
+                        placeholder="Ex: Rapports d'intervention"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="folder-description">Description</Label>
+                      <Textarea
+                        id="folder-description"
+                        value={folderForm.description}
+                        onChange={(e) => setFolderForm({...folderForm, description: e.target.value})}
+                        placeholder="Description du dossier"
+                        rows={3}
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button variant="outline" onClick={() => setIsCreateFolderModalOpen(false)}>
+                      Annuler
+                    </Button>
+                    <Button onClick={handleCreateFolder}>
+                      Créer
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+
+              <Dialog open={isCreateReportModalOpen} onOpenChange={setIsCreateReportModalOpen}>
+                <DialogTrigger asChild>
+                  <Button className="bg-green-600 hover:bg-green-700">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Nouveau rapport
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+                  <DialogHeader>
+                    <DialogTitle>Créer un nouveau rapport</DialogTitle>
+                  </DialogHeader>
+                  <div className="space-y-6">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label htmlFor="report-title">Titre du rapport</Label>
+                        <Input
+                          id="report-title"
+                          value={reportForm.title}
+                          onChange={(e) => setReportForm({...reportForm, title: e.target.value})}
+                          placeholder="Ex: Rapport d'intervention - Serre A12"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="report-type">Type de rapport</Label>
+                        <Select value={reportForm.type} onValueChange={(value: any) => setReportForm({...reportForm, type: value})}>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="intervention">Intervention</SelectItem>
+                            <SelectItem value="inspection">Inspection</SelectItem>
+                            <SelectItem value="maintenance">Maintenance</SelectItem>
+                            <SelectItem value="incident">Incident</SelectItem>
+                            <SelectItem value="monthly">Mensuel</SelectItem>
+                            <SelectItem value="annual">Annuel</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div>
+                        <Label htmlFor="report-folder">Dossier</Label>
+                        <Select value={reportForm.folderId} onValueChange={(value) => setReportForm({...reportForm, folderId: value})}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Sélectionner un dossier" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {folders.map((folder) => (
+                              <SelectItem key={folder.id} value={folder.id}>
+                                {folder.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div>
+                        <Label htmlFor="report-tags">Tags (séparés par virgules)</Label>
+                        <Input
+                          id="report-tags"
+                          value={reportForm.tags}
+                          onChange={(e) => setReportForm({...reportForm, tags: e.target.value})}
+                          placeholder="irrigation, maintenance, urgent"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="report-location">Localisation</Label>
+                        <Input
+                          id="report-location"
+                          value={reportForm.location}
+                          onChange={(e) => setReportForm({...reportForm, location: e.target.value})}
+                          placeholder="Ex: Serre A12, Zone Nord"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="report-technician">Technicien</Label>
+                        <Input
+                          id="report-technician"
+                          value={reportForm.technician}
+                          onChange={(e) => setReportForm({...reportForm, technician: e.target.value})}
+                          placeholder="Nom du technicien"
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label htmlFor="report-content">Contenu du rapport</Label>
+                      <WYSIWYGEditor
+                        content={reportForm.content}
+                        onChange={(content) => setReportForm({...reportForm, content})}
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button variant="outline" onClick={() => {setIsCreateReportModalOpen(false); resetReportForm();}}>
+                      Annuler
+                    </Button>
+                    <Button onClick={handleCreateReport}>
+                      Créer le rapport
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Total rapports</p>
+                    <p className="text-3xl font-bold text-blue-600">{reports.length}</p>
+                  </div>
+                  <FileText className="h-8 w-8 text-blue-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Brouillons</p>
+                    <p className="text-3xl font-bold text-gray-600">{draftCount}</p>
+                  </div>
+                  <Edit className="h-8 w-8 text-gray-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Terminés</p>
+                    <p className="text-3xl font-bold text-blue-600">{completedCount}</p>
+                  </div>
+                  <FileDown className="h-8 w-8 text-blue-600" />
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Publiés</p>
+                    <p className="text-3xl font-bold text-green-600">{publishedCount}</p>
+                  </div>
+                  <Share className="h-8 w-8 text-green-600" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Tabs */}
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="reports">Rapports ({reports.length})</TabsTrigger>
+              <TabsTrigger value="folders">Dossiers ({folders.length})</TabsTrigger>
+            </TabsList>
+
+            {/* Reports Tab */}
+            <TabsContent value="reports" className="space-y-6">
+              {/* Filters */}
+              <Card>
+                <CardContent className="p-4">
+                  <div className="flex flex-col md:flex-row gap-4">
+                    <div className="flex-1">
+                      <div className="relative">
+                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                        <Input
+                          placeholder="Rechercher rapports..."
+                          value={searchTerm}
+                          onChange={(e) => setSearchTerm(e.target.value)}
+                          className="pl-10"
+                        />
+                      </div>
+                    </div>
+                    <Select value={selectedFolder} onValueChange={setSelectedFolder}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Dossier" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Tous les dossiers</SelectItem>
+                        {folders.map((folder) => (
+                          <SelectItem key={folder.id} value={folder.id}>
+                            {folder.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select value={selectedType} onValueChange={setSelectedType}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Tous les types</SelectItem>
+                        <SelectItem value="intervention">Intervention</SelectItem>
+                        <SelectItem value="inspection">Inspection</SelectItem>
+                        <SelectItem value="maintenance">Maintenance</SelectItem>
+                        <SelectItem value="incident">Incident</SelectItem>
+                        <SelectItem value="monthly">Mensuel</SelectItem>
+                        <SelectItem value="annual">Annuel</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Select value={selectedStatus} onValueChange={setSelectedStatus}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Statut" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Tous statuts</SelectItem>
+                        <SelectItem value="draft">Brouillon</SelectItem>
+                        <SelectItem value="completed">Terminé</SelectItem>
+                        <SelectItem value="published">Publié</SelectItem>
+                        <SelectItem value="archived">Archivé</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Reports List */}
+              <div className="space-y-4">
+                {filteredReports.map((report) => (
+                  <Card key={report.id} className="hover:shadow-md transition-shadow">
+                    <CardContent className="p-6">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center space-x-3 mb-2">
+                            <h3 className="text-lg font-semibold text-gray-900">
+                              {report.title}
+                            </h3>
+                            <Badge variant="outline" className={getTypeColor(report.type)}>
+                              {getTypeDisplayName(report.type)}
+                            </Badge>
+                            <Badge variant="outline" className={getStatusColor(report.status)}>
+                              {getStatusDisplayName(report.status)}
+                            </Badge>
+                          </div>
+                          
+                          <p className="text-gray-600 mb-3 line-clamp-2">
+                            {report.content.substring(0, 150)}...
+                          </p>
+                          
+                          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-gray-600">
+                            <div className="flex items-center">
+                              <User className="h-4 w-4 mr-1" />
+                              {report.createdBy}
+                            </div>
+                            <div className="flex items-center">
+                              <Calendar className="h-4 w-4 mr-1" />
+                              {new Date(report.createdDate).toLocaleDateString('fr-FR')}
+                            </div>
+                            <div className="flex items-center">
+                              <Folder className="h-4 w-4 mr-1" />
+                              {folders.find(f => f.id === report.folderId)?.name || "Aucun dossier"}
+                            </div>
+                            {report.metadata?.location && (
+                              <div className="flex items-center">
+                                <Search className="h-4 w-4 mr-1" />
+                                {report.metadata.location}
+                              </div>
+                            )}
+                          </div>
+
+                          {report.tags && report.tags.length > 0 && (
+                            <div className="mt-3 flex flex-wrap gap-1">
+                              {report.tags.map((tag, index) => (
+                                <Badge key={index} variant="secondary" className="text-xs">
+                                  {tag}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+
+                        <div className="flex items-center space-x-2 ml-4">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setViewingReport(report)}
+                          >
+                            <Eye className="h-4 w-4 mr-1" />
+                            Voir
+                          </Button>
+
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => exportToPDF(report)}
+                          >
+                            <Download className="h-4 w-4 mr-1" />
+                            PDF
+                          </Button>
+
+                          <Dialog open={editingReport?.id === report.id} onOpenChange={(open) => !open && setEditingReport(null)}>
+                            <DialogTrigger asChild>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => handleEditReport(report)}
+                              >
+                                <Edit className="h-4 w-4" />
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+                              <DialogHeader>
+                                <DialogTitle>Modifier le rapport</DialogTitle>
+                              </DialogHeader>
+                              <div className="space-y-6">
+                                <div className="grid grid-cols-2 gap-4">
+                                  <div>
+                                    <Label htmlFor="edit-title">Titre</Label>
+                                    <Input
+                                      id="edit-title"
+                                      value={reportForm.title}
+                                      onChange={(e) => setReportForm({...reportForm, title: e.target.value})}
+                                    />
+                                  </div>
+                                  <div>
+                                    <Label htmlFor="edit-type">Type</Label>
+                                    <Select value={reportForm.type} onValueChange={(value: any) => setReportForm({...reportForm, type: value})}>
+                                      <SelectTrigger>
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="intervention">Intervention</SelectItem>
+                                        <SelectItem value="inspection">Inspection</SelectItem>
+                                        <SelectItem value="maintenance">Maintenance</SelectItem>
+                                        <SelectItem value="incident">Incident</SelectItem>
+                                        <SelectItem value="monthly">Mensuel</SelectItem>
+                                        <SelectItem value="annual">Annuel</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                  </div>
+                                  <div>
+                                    <Label htmlFor="edit-folder">Dossier</Label>
+                                    <Select value={reportForm.folderId} onValueChange={(value) => setReportForm({...reportForm, folderId: value})}>
+                                      <SelectTrigger>
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        {folders.map((folder) => (
+                                          <SelectItem key={folder.id} value={folder.id}>
+                                            {folder.name}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  </div>
+                                  <div>
+                                    <Label htmlFor="edit-tags">Tags</Label>
+                                    <Input
+                                      id="edit-tags"
+                                      value={reportForm.tags}
+                                      onChange={(e) => setReportForm({...reportForm, tags: e.target.value})}
+                                    />
+                                  </div>
+                                </div>
+
+                                <div>
+                                  <Label>Contenu du rapport</Label>
+                                  <WYSIWYGEditor
+                                    content={reportForm.content}
+                                    onChange={(content) => setReportForm({...reportForm, content})}
+                                  />
+                                </div>
+                              </div>
+                              <DialogFooter>
+                                <Button variant="outline" onClick={() => setEditingReport(null)}>
+                                  Annuler
+                                </Button>
+                                <Button onClick={handleUpdateReport}>
+                                  Sauvegarder
+                                </Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
+
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="outline" size="sm" className="text-red-600 hover:text-red-700">
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Supprimer le rapport</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Êtes-vous sûr de vouloir supprimer ce rapport ? 
+                                  Cette action est irréversible.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => handleDeleteReport(report.id)}
+                                  className="bg-red-600 hover:bg-red-700"
+                                >
+                                  Supprimer
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+
+                {filteredReports.length === 0 && (
+                  <Card>
+                    <CardContent className="p-12 text-center">
+                      <FileText className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                      <h3 className="text-lg font-medium text-gray-900 mb-2">
+                        Aucun rapport trouvé
+                      </h3>
+                      <p className="text-gray-600">
+                        Aucun rapport ne correspond à vos critères de recherche.
+                      </p>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            </TabsContent>
+
+            {/* Folders Tab */}
+            <TabsContent value="folders" className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {folders.map((folder) => (
+                  <Card key={folder.id} className="hover:shadow-md transition-shadow">
+                    <CardContent className="p-6">
+                      <div className="flex items-start justify-between">
+                        <div className="flex items-center space-x-3">
+                          <div className="p-3 bg-blue-100 rounded-lg">
+                            <Folder className="h-6 w-6 text-blue-600" />
+                          </div>
+                          <div>
+                            <h3 className="font-semibold text-gray-900">{folder.name}</h3>
+                            <p className="text-sm text-gray-600 mt-1">{folder.description}</p>
+                            <p className="text-xs text-gray-500 mt-2">
+                              {folder.reportCount} rapport(s) • Créé le {new Date(folder.createdDate).toLocaleDateString('fr-FR')}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+
+      {/* Report Viewer Modal */}
+      <Dialog open={!!viewingReport} onOpenChange={() => setViewingReport(null)}>
+        <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center justify-between">
+              <span>Aperçu du rapport</span>
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => viewingReport && exportToPDF(viewingReport)}
+                >
+                  <Download className="h-4 w-4 mr-1" />
+                  Exporter PDF
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => window.print()}
+                >
+                  <Printer className="h-4 w-4 mr-1" />
+                  Imprimer
+                </Button>
+              </div>
+            </DialogTitle>
+          </DialogHeader>
+          {viewingReport && (
+            <ScrollArea className="max-h-[70vh]">
+              <PDFViewer reportContent={viewingReport.content} title={viewingReport.title} />
+            </ScrollArea>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/front-end-ui/client/pages/TechnicianManagement.tsx
+++ b/front-end-ui/client/pages/TechnicianManagement.tsx
@@ -1,0 +1,569 @@
+import React, { useState, useEffect } from "react";
+import DirectorSidebar from "../components/DirectorSidebar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogTrigger,
+  DialogFooter 
+} from "@/components/ui/dialog";
+import { 
+  Select, 
+  SelectContent, 
+  SelectItem, 
+  SelectTrigger, 
+  SelectValue 
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Users,
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  UserCheck,
+  UserX,
+  Mail,
+  Phone,
+  MapPin,
+  Shield
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface Technician {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  role: "technicien" | "technicien_sup";
+  status: "active" | "inactive" | "pending";
+  location?: string;
+  joinDate: string;
+  interventions: number;
+  avatar?: string;
+}
+
+export default function TechnicianManagement() {
+  const { toast } = useToast();
+  const [technicians, setTechnicians] = useState<Technician[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedRole, setSelectedRole] = useState<string>("all");
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingTechnician, setEditingTechnician] = useState<Technician | null>(null);
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    phone: "",
+    role: "technicien" as "technicien" | "technicien_sup",
+    location: ""
+  });
+
+  // Mock data - replace with real API calls
+  useEffect(() => {
+    const mockTechnicians: Technician[] = [
+      {
+        id: "1",
+        name: "Marie Dubois",
+        email: "marie.dubois@example.com",
+        phone: "+33 6 12 34 56 78",
+        role: "technicien_sup",
+        status: "active",
+        location: "Paris, France",
+        joinDate: "2023-01-15",
+        interventions: 45
+      },
+      {
+        id: "2",
+        name: "Jean Martin",
+        email: "jean.martin@example.com",
+        phone: "+33 6 98 76 54 32",
+        role: "technicien",
+        status: "active",
+        location: "Lyon, France",
+        joinDate: "2023-03-20",
+        interventions: 32
+      },
+      {
+        id: "3",
+        name: "Sophie Lambert",
+        email: "sophie.lambert@example.com",
+        role: "technicien",
+        status: "pending",
+        location: "Marseille, France",
+        joinDate: "2024-01-10",
+        interventions: 8
+      },
+      {
+        id: "4",
+        name: "Pierre Durand",
+        email: "pierre.durand@example.com",
+        phone: "+33 6 55 44 33 22",
+        role: "technicien_sup",
+        status: "inactive",
+        location: "Toulouse, France",
+        joinDate: "2022-11-05",
+        interventions: 67
+      }
+    ];
+    setTechnicians(mockTechnicians);
+  }, []);
+
+  const filteredTechnicians = technicians.filter(tech => {
+    const matchesSearch = tech.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                         tech.email.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesRole = selectedRole === "all" || tech.role === selectedRole;
+    const matchesStatus = selectedStatus === "all" || tech.status === selectedStatus;
+    
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  const handleCreateTechnician = () => {
+    const newTechnician: Technician = {
+      id: Date.now().toString(),
+      ...formData,
+      status: "pending",
+      joinDate: new Date().toISOString().split('T')[0],
+      interventions: 0
+    };
+
+    setTechnicians([...technicians, newTechnician]);
+    setIsCreateModalOpen(false);
+    setFormData({ name: "", email: "", phone: "", role: "technicien", location: "" });
+    
+    toast({
+      title: "Technicien créé",
+      description: `${newTechnician.name} a été ajouté avec succès.`,
+    });
+  };
+
+  const handleEditTechnician = (technician: Technician) => {
+    setEditingTechnician(technician);
+    setFormData({
+      name: technician.name,
+      email: technician.email,
+      phone: technician.phone || "",
+      role: technician.role,
+      location: technician.location || ""
+    });
+  };
+
+  const handleUpdateTechnician = () => {
+    if (!editingTechnician) return;
+
+    const updatedTechnicians = technicians.map(tech =>
+      tech.id === editingTechnician.id
+        ? { ...tech, ...formData }
+        : tech
+    );
+
+    setTechnicians(updatedTechnicians);
+    setEditingTechnician(null);
+    setFormData({ name: "", email: "", phone: "", role: "technicien", location: "" });
+    
+    toast({
+      title: "Technicien mis à jour",
+      description: `Les informations ont été sauvegardées.`,
+    });
+  };
+
+  const handleDeleteTechnician = (id: string) => {
+    const technicianName = technicians.find(t => t.id === id)?.name;
+    setTechnicians(technicians.filter(tech => tech.id !== id));
+    
+    toast({
+      title: "Technicien supprimé",
+      description: `${technicianName} a été supprimé du système.`,
+      variant: "destructive",
+    });
+  };
+
+  const handleStatusChange = (id: string, newStatus: "active" | "inactive") => {
+    const updatedTechnicians = technicians.map(tech =>
+      tech.id === id ? { ...tech, status: newStatus } : tech
+    );
+    setTechnicians(updatedTechnicians);
+    
+    toast({
+      title: "Statut mis à jour",
+      description: `Le statut du technicien a été changé.`,
+    });
+  };
+
+  const getRoleDisplayName = (role: string) => {
+    return role === "technicien_sup" ? "Technicien Supérieur" : "Technicien";
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "active":
+        return "bg-green-50 border-green-200 text-green-700";
+      case "inactive":
+        return "bg-red-50 border-red-200 text-red-700";
+      case "pending":
+        return "bg-yellow-50 border-yellow-200 text-yellow-700";
+      default:
+        return "bg-gray-50 border-gray-200 text-gray-700";
+    }
+  };
+
+  const getStatusDisplayName = (status: string) => {
+    switch (status) {
+      case "active":
+        return "Actif";
+      case "inactive":
+        return "Inactif";
+      case "pending":
+        return "En attente";
+      default:
+        return "Non défini";
+    }
+  };
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <DirectorSidebar />
+      
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                Gestion des techniciens
+              </h1>
+              <p className="text-gray-600 mt-1">
+                Gérez les comptes et autorisations des techniciens
+              </p>
+            </div>
+            <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+              <DialogTrigger asChild>
+                <Button className="bg-green-600 hover:bg-green-700">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Ajouter technicien
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Créer un nouveau technicien</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="name">Nom complet</Label>
+                    <Input
+                      id="name"
+                      value={formData.name}
+                      onChange={(e) => setFormData({...formData, name: e.target.value})}
+                      placeholder="Nom du technicien"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) => setFormData({...formData, email: e.target.value})}
+                      placeholder="email@example.com"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="phone">Téléphone</Label>
+                    <Input
+                      id="phone"
+                      value={formData.phone}
+                      onChange={(e) => setFormData({...formData, phone: e.target.value})}
+                      placeholder="+33 6 12 34 56 78"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="role">Rôle</Label>
+                    <Select value={formData.role} onValueChange={(value: "technicien" | "technicien_sup") => setFormData({...formData, role: value})}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="technicien">Technicien</SelectItem>
+                        <SelectItem value="technicien_sup">Technicien Supérieur</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="location">Localisation</Label>
+                    <Input
+                      id="location"
+                      value={formData.location}
+                      onChange={(e) => setFormData({...formData, location: e.target.value})}
+                      placeholder="Ville, Pays"
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsCreateModalOpen(false)}>
+                    Annuler
+                  </Button>
+                  <Button onClick={handleCreateTechnician}>
+                    Créer
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {/* Filters and Search */}
+          <Card className="mb-6">
+            <CardContent className="p-4">
+              <div className="flex flex-col md:flex-row gap-4">
+                <div className="flex-1">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                    <Input
+                      placeholder="Rechercher par nom ou email..."
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+                <Select value={selectedRole} onValueChange={setSelectedRole}>
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Filtrer par rôle" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Tous les rôles</SelectItem>
+                    <SelectItem value="technicien">Technicien</SelectItem>
+                    <SelectItem value="technicien_sup">Technicien Supérieur</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={selectedStatus} onValueChange={setSelectedStatus}>
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Filtrer par statut" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Tous les statuts</SelectItem>
+                    <SelectItem value="active">Actif</SelectItem>
+                    <SelectItem value="inactive">Inactif</SelectItem>
+                    <SelectItem value="pending">En attente</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Technicians List */}
+          <div className="grid gap-4">
+            {filteredTechnicians.map((technician) => (
+              <Card key={technician.id} className="hover:shadow-md transition-shadow">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                      <Avatar className="h-12 w-12">
+                        <AvatarImage src={technician.avatar} />
+                        <AvatarFallback>
+                          {technician.name.split(' ').map(n => n[0]).join('')}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <h3 className="text-lg font-semibold text-gray-900">
+                          {technician.name}
+                        </h3>
+                        <div className="flex items-center space-x-4 text-sm text-gray-600">
+                          <span className="flex items-center">
+                            <Mail className="h-4 w-4 mr-1" />
+                            {technician.email}
+                          </span>
+                          {technician.phone && (
+                            <span className="flex items-center">
+                              <Phone className="h-4 w-4 mr-1" />
+                              {technician.phone}
+                            </span>
+                          )}
+                          {technician.location && (
+                            <span className="flex items-center">
+                              <MapPin className="h-4 w-4 mr-1" />
+                              {technician.location}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center space-x-4">
+                      <div className="text-right">
+                        <Badge variant="outline" className="mb-2">
+                          <Shield className="h-3 w-3 mr-1" />
+                          {getRoleDisplayName(technician.role)}
+                        </Badge>
+                        <div>
+                          <Badge variant="outline" className={getStatusColor(technician.status)}>
+                            {getStatusDisplayName(technician.status)}
+                          </Badge>
+                        </div>
+                      </div>
+
+                      <div className="text-right text-sm text-gray-600">
+                        <div>{technician.interventions} interventions</div>
+                        <div>Depuis {new Date(technician.joinDate).toLocaleDateString('fr-FR')}</div>
+                      </div>
+
+                      <div className="flex items-center space-x-2">
+                        {technician.status === "active" ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleStatusChange(technician.id, "inactive")}
+                          >
+                            <UserX className="h-4 w-4" />
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleStatusChange(technician.id, "active")}
+                          >
+                            <UserCheck className="h-4 w-4" />
+                          </Button>
+                        )}
+
+                        <Dialog open={editingTechnician?.id === technician.id} onOpenChange={(open) => !open && setEditingTechnician(null)}>
+                          <DialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleEditTechnician(technician)}
+                            >
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent className="sm:max-w-md">
+                            <DialogHeader>
+                              <DialogTitle>Modifier le technicien</DialogTitle>
+                            </DialogHeader>
+                            <div className="space-y-4">
+                              <div>
+                                <Label htmlFor="edit-name">Nom complet</Label>
+                                <Input
+                                  id="edit-name"
+                                  value={formData.name}
+                                  onChange={(e) => setFormData({...formData, name: e.target.value})}
+                                />
+                              </div>
+                              <div>
+                                <Label htmlFor="edit-email">Email</Label>
+                                <Input
+                                  id="edit-email"
+                                  type="email"
+                                  value={formData.email}
+                                  onChange={(e) => setFormData({...formData, email: e.target.value})}
+                                />
+                              </div>
+                              <div>
+                                <Label htmlFor="edit-phone">Téléphone</Label>
+                                <Input
+                                  id="edit-phone"
+                                  value={formData.phone}
+                                  onChange={(e) => setFormData({...formData, phone: e.target.value})}
+                                />
+                              </div>
+                              <div>
+                                <Label htmlFor="edit-role">Rôle</Label>
+                                <Select value={formData.role} onValueChange={(value: "technicien" | "technicien_sup") => setFormData({...formData, role: value})}>
+                                  <SelectTrigger>
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="technicien">Technicien</SelectItem>
+                                    <SelectItem value="technicien_sup">Technicien Supérieur</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                              <div>
+                                <Label htmlFor="edit-location">Localisation</Label>
+                                <Input
+                                  id="edit-location"
+                                  value={formData.location}
+                                  onChange={(e) => setFormData({...formData, location: e.target.value})}
+                                />
+                              </div>
+                            </div>
+                            <DialogFooter>
+                              <Button variant="outline" onClick={() => setEditingTechnician(null)}>
+                                Annuler
+                              </Button>
+                              <Button onClick={handleUpdateTechnician}>
+                                Sauvegarder
+                              </Button>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
+
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button variant="outline" size="sm" className="text-red-600 hover:text-red-700">
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Supprimer le technicien</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Êtes-vous sûr de vouloir supprimer {technician.name} ? 
+                                Cette action est irréversible.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Annuler</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleDeleteTechnician(technician.id)}
+                                className="bg-red-600 hover:bg-red-700"
+                              >
+                                Supprimer
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {filteredTechnicians.length === 0 && (
+            <Card>
+              <CardContent className="p-12 text-center">
+                <Users className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  Aucun technicien trouvé
+                </h3>
+                <p className="text-gray-600">
+                  Aucun technicien ne correspond à vos critères de recherche.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Purpose

The user requested improved UX for accessing user profiles. Previously, users could access profiles by clicking on the username in the header, but this wasn't intuitive or discoverable. The goal was to make profile access more obvious and user-friendly.

## Code changes

- **Enhanced header UX**: Replaced simple username text with an interactive dropdown menu featuring:
  - User avatar icon with blue styling
  - User name and email display
  - Chevron down indicator for discoverability
  - Hover effects and smooth transitions

- **Added profile dropdown menu** with:
  - User info display at the top
  - "Mon Profil" navigation option
  - Logout functionality with visual separation

- **Created dedicated Profile page** (`/pages/Profile.tsx`) featuring:
  - Comprehensive user information display
  - Editable profile fields (name, email)
  - Role and status information with color-coded badges
  - Save/cancel functionality for profile updates

- **Added profile routing**: New `/profile` route with protected access

The changes significantly improve profile discoverability through visual cues (dropdown arrow, hover effects) and provide a complete profile management experience.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 197`

🔗 [Edit in Builder.io](https://builder.io/app/projects/12ff3d5e7da645259f71a18edd387658/echo-den)

👀 [Preview Link](https://12ff3d5e7da645259f71a18edd387658-echo-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>12ff3d5e7da645259f71a18edd387658</projectId>-->
<!--<branchName>echo-den</branchName>-->