### PR TITLE
Add robot control page with header and sidebar navigation

### DIFF
--- a/front-end-ui/client/components/DirectorSidebar.tsx
+++ b/front-end-ui/client/components/DirectorSidebar.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { 
-  Users, 
-  UserCheck, 
-  ClipboardList, 
-  AlertTriangle, 
+import {
+  Users,
+  UserCheck,
+  ClipboardList,
+  AlertTriangle,
   FileText,
   LayoutDashboard,
   Menu,
@@ -12,7 +12,8 @@ import {
   ChevronRight,
   Settings,
   BarChart3,
-  MapPin
+  MapPin,
+  Bot
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -78,6 +79,13 @@ const navigationItems = [
     icon: MapPin,
     href: '/director/locations',
     description: 'Domaines, serres et géolocalisation'
+  },
+  {
+    id: 'robot-control',
+    label: 'Contrôle Robot',
+    icon: Bot,
+    href: '/robot-control',
+    description: 'Surveillance et contrôle du robot en temps réel'
   }
 ];
 

--- a/front-end-ui/client/pages/RobotControl.tsx
+++ b/front-end-ui/client/pages/RobotControl.tsx
@@ -1,20 +1,23 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { 
-  Play, 
-  Pause, 
-  ArrowRight, 
-  ArrowLeft, 
-  ArrowUp, 
+import {
+  Play,
+  Pause,
+  ArrowRight,
+  ArrowLeft,
+  ArrowUp,
   ArrowDown,
   Video,
   Wifi,
   Thermometer,
   Droplets,
   Zap,
-  Sun
+  Sun,
+  Menu
 } from 'lucide-react';
+import { useSidebar } from '@/hooks/useSidebar';
+import DirectorSidebar from '../components/DirectorSidebar';
 
 interface QRData {
   [key: string]: any;
@@ -32,6 +35,7 @@ interface ControlCommand {
 }
 
 export default function RobotControl() {
+  const { isOpen, setIsOpen } = useSidebar();
   const videoRef = useRef<HTMLVideoElement>(null);
   const [qrCodes, setQrCodes] = useState<QRData[]>([]);
   const [sensorData, setSensorData] = useState<SensorData | null>(null);
@@ -274,9 +278,36 @@ export default function RobotControl() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background p-6">
-      <div className="container mx-auto">
-        <h1 className="text-3xl font-bold mb-6 text-center">Robot Control Interface</h1>
+    <div className="min-h-screen bg-gray-50 flex">
+      <DirectorSidebar isOpen={isOpen} setIsOpen={setIsOpen} />
+
+      <div className="flex-1 overflow-auto">
+        {/* Header */}
+        <div className="bg-white border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsOpen(!isOpen)}
+                className="lg:hidden"
+              >
+                <Menu className="h-5 w-5" />
+              </Button>
+              <div>
+                <h1 className="text-2xl font-semibold text-gray-900">
+                  Contrôle Robot
+                </h1>
+                <p className="text-gray-600 mt-1">
+                  Interface de contrôle et surveillance en temps réel
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          <div className="container mx-auto">
         
         {/* Connection Status */}
         <div className="grid grid-cols-4 gap-4 mb-6">
@@ -426,6 +457,8 @@ export default function RobotControl() {
             </div>
           </CardContent>
         </Card>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Purpose
Add a comprehensive robot control page to the application with proper navigation integration. The user requested to include header and sidebar menu components consistent with other pages, and add a navigation link in the sidebar to access this new functionality.

## Code changes
- **New RobotControl page**: Created a complete robot control interface with real-time video streaming, sensor data display, QR code detection, and manual robot controls
- **Routing integration**: Added `/robot-control` route in App.tsx with proper authentication protection
- **Sidebar navigation**: Added "Contrôle Robot" menu item with Bot icon to DirectorSidebar component
- **Layout consistency**: Implemented header with menu toggle and sidebar integration matching other pages
- **Bug fixes**: Fixed syntax errors in SerreCreation component (missing closing brace, error handling)

The robot control page includes WebRTC video streaming, WebSocket connections for real-time data, and comprehensive control buttons for robot operation.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 234`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5bd08b2f485248d5940ee3e4a7402318/spark-zone)

👀 [Preview Link](https://5bd08b2f485248d5940ee3e4a7402318-spark-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5bd08b2f485248d5940ee3e4a7402318</projectId>-->
<!--<branchName>spark-zone</branchName>-->