### PR TITLE
Add robot control page with header and sidebar integration

### DIFF
--- a/front-end-ui/client/components/TechnicianSidebar.tsx
+++ b/front-end-ui/client/components/TechnicianSidebar.tsx
@@ -13,6 +13,7 @@ import {
   LogOut,
   Menu,
   X,
+  Bot,
 } from "lucide-react";
 
 interface SidebarItem {
@@ -89,6 +90,12 @@ export default function TechnicianSidebar({
       label: "Rapports",
       icon: <Bookmark className="h-5 w-5" />,
       path: "/reports",
+    },
+    {
+      id: "robot-control",
+      label: "Contrôle Robot",
+      icon: <Bot className="h-5 w-5" />,
+      path: "/robot-control",
     },
   ];
 

--- a/front-end-ui/client/pages/RobotControl.tsx
+++ b/front-end-ui/client/pages/RobotControl.tsx
@@ -275,9 +275,19 @@ export default function RobotControl() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background p-6">
-      <div className="container mx-auto">
-        <h1 className="text-3xl font-bold mb-6 text-center">Robot Control Interface</h1>
+    <div className="min-h-screen bg-gray-50">
+      <PageHeader
+        title="Contrôle Robot"
+        subtitle="Interface de contrôle du robot autonome"
+        userRole="technicien"
+        badge={{
+          text: "En Ligne",
+          variant: "outline",
+          className: "bg-green-50 border-green-200 text-green-700"
+        }}
+      />
+
+      <div className="container mx-auto p-6">
         
         {/* Connection Status */}
         <div className="grid grid-cols-4 gap-4 mb-6">

--- a/front-end-ui/client/pages/RobotControl.tsx
+++ b/front-end-ui/client/pages/RobotControl.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { 
-  Play, 
-  Pause, 
-  ArrowRight, 
-  ArrowLeft, 
-  ArrowUp, 
+import PageHeader from '@/components/PageHeader';
+import {
+  Play,
+  Pause,
+  ArrowRight,
+  ArrowLeft,
+  ArrowUp,
   ArrowDown,
   Video,
   Wifi,


### PR DESCRIPTION
## Purpose

Add a new robot control page to the technician interface with proper navigation integration. The user requested to create a robot control page that follows the same structure as other pages, including the technician header and sidebar menu, and to add a navigation link in the technician sidebar.

## Code changes

- **New RobotControl page**: Created a comprehensive robot control interface with live video streaming, sensor data display, QR code detection, and robot movement controls
- **Routing**: Added `/robot-control` route in App.tsx with proper authentication protection
- **Navigation**: Added "Contrôle Robot" menu item with Bot icon to TechnicianSidebar component
- **Page structure**: Implemented PageHeader component with technician role and proper styling
- **Bug fixes**: Fixed syntax errors in SerreCreation.tsx including missing closing braces and error handling blocks
- **UI components**: Added connection status indicators, sensor data visualization, and control buttons for robot movement

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 235`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9bdf4b35fe844e54b13ebe028149814a/pulse-space)

👀 [Preview Link](https://9bdf4b35fe844e54b13ebe028149814a-pulse-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9bdf4b35fe844e54b13ebe028149814a</projectId>-->
<!--<branchName>pulse-space</branchName>-->